### PR TITLE
style: remove useless move found via clang-tidy

### DIFF
--- a/include/treespec.h
+++ b/include/treespec.h
@@ -179,13 +179,8 @@ class PyTreeSpec {
                 INTERNAL_ERROR();
         }
 
-        h = H::combine(std::move(h),
-                       n.kind,
-                       n.arity,
-                       n.custom,
-                       n.num_leaves,
-                       n.num_nodes,
-                       std::move(data_hash));
+        h = H::combine(
+            std::move(h), n.kind, n.arity, n.custom, n.num_leaves, n.num_nodes, data_hash);
         return h;
     }
 


### PR DESCRIPTION
Signed-off-by: Aaron Gokaslan <aaronGokaslan@gmail.com>

## Description

Describe your changes in detail.
* Remove a move that doesn't do anything found via clang-tidy (data_hash is an ssize_t).

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://optree.readthedocs.io/en/latest/developer/contributing.html) guide. (**required**)