### PR TITLE
feat: build Linux AArch64 and Windows ARM64 wheels (#25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
       - include/**
       - src/**
       - optree/version.py
-      - .github/workflow/build.yml
+      - .github/workflows/build.yml
   release:
     types:
       - published
@@ -87,7 +87,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.7"]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -113,10 +113,17 @@ jobs:
       - name: Set CIBW_BUILD
         run: python .github/workflows/set_cibw_build.py
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
+          CIBW_ARCHS_LINUX: auto64 aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         with:
           package-dir: .
@@ -139,7 +146,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -165,10 +172,17 @@ jobs:
       - name: Set CIBW_BUILD
         run: python .github/workflows/set_cibw_build.py
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
+          CIBW_ARCHS_LINUX: auto64 aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         with:
           package-dir: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_ARCHS_LINUX: auto64 aarch64
+          CIBW_ARCHS_WINDOWS: auto64 ARM64
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         with:
           package-dir: .
@@ -183,6 +184,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
           CIBW_ARCHS_LINUX: auto64 aarch64
+          CIBW_ARCHS_WINDOWS: auto64 ARM64
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         with:
           package-dir: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ include = ["optree", "optree.*"]
 # Reference: https://cibuildwheel.readthedocs.io
 [tool.cibuildwheel]
 archs = ["auto64"]
+skip = "*musllinux*"
 build-frontend = "build"
 build-verbosity = 3
 container-engine = "docker"


### PR DESCRIPTION
## Description

Describe your changes in detail.

Add pre-build wheel for Linux aarch64 ~and ppc64le/s390x~ and Windows arm64.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
