### PR TITLE
style: make error message more clear when value mismatch

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,14 +3,15 @@ max-line-length = 120
 max-doc-length = 100
 select = B,C,E,F,W,Y,SIM
 ignore =
+    # E203: whitespace before ':'
+    # W503: line break before binary operator
+    # W504: line break after binary operator
+    # format by black
+    E203,W503,W504,
     # E501: line too long
     # W505: doc line too long
     # too long docstring due to long example blocks
     E501,W505,
-    # W503: line break before binary operator
-    # W504: line break after binary operator
-    # format by black
-    W503,W504,
 per-file-ignores =
     # F401: module imported but unused
     # intentionally unused imports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: clang-format
         stages: [commit, push, manual]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.249
+    rev: v0.0.252
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Make error message more clear when value mismatch by [@XuehaiPan](https://github.com/XuehaiPan) in [#36](https://github.com/metaopt/optree/pull/36).
 - Add `ruff` and `flake8` plugins integration by [@XuehaiPan](https://github.com/XuehaiPan) in [#33](https://github.com/metaopt/optree/pull/33) and [#34](https://github.com/metaopt/optree/pull/34).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -380,7 +380,9 @@ There are several key attributes of the pytree type registry:
 
     # Children are also `np.ndarray`s, recurse without termination condition.
     >>> optree.tree_flatten(np.arange(9).reshape(3, 3), namespace='numpy3')
-    RecursionError: maximum recursion depth exceeded during flattening the tree
+    Traceback (most recent call last):
+        ...
+    RecursionError: Maximum recursion depth exceeded during flattening the tree.
 
     >>> optree.tree_flatten(torch.arange(9).reshape(3, 3), namespace='torch1')
     (
@@ -398,7 +400,9 @@ There are several key attributes of the pytree type registry:
 
     # Children are also `torch.Tensor`s, recurse without termination condition.
     >>> optree.tree_flatten(torch.arange(9).reshape(3, 3), namespace='torch2')
-    RecursionError: maximum recursion depth exceeded during flattening the tree
+    Traceback (most recent call last):
+        ...
+    RecursionError: Maximum recursion depth exceeded during flattening the tree.
     ```
 
 ### `None` is Non-leaf Node vs. `None` is Leaf
@@ -451,6 +455,8 @@ OrderedDict([
 ])
 
 >>> optree.tree_map(torch.zeros_like, linear._parameters, none_is_leaf=True)
+Traceback (most recent call last):
+    ...
 TypeError: zeros_like(): argument 'input' (position 1) must be Tensor, not NoneType
 
 >>> optree.tree_map(lambda t: torch.zeros_like(t) if t is not None else 0, linear._parameters, none_is_leaf=True)
@@ -484,6 +490,8 @@ The keys are sorted in ascending order by `key=lambda k: k` first if capable oth
 >>> sorted({1: 2, 1.5: 1}.keys())
 [1, 1.5]
 >>> sorted({'a': 3, 1: 2, 1.5: 1}.keys())
+Traceback (most recent call last):
+    ...
 TypeError: '<' not supported between instances of 'int' and 'str'
 >>> sorted({'a': 3, 1: 2, 1.5: 1}.keys(), key=lambda k: (k.__class__.__qualname__, k))
 [1.5, 1, 'a']

--- a/include/utils.h
+++ b/include/utils.h
@@ -314,19 +314,22 @@ inline void AssertExact(const py::handle& object) {
 template <>
 inline void AssertExact<py::list>(const py::handle& object) {
     if (!PyList_CheckExact(object.ptr())) [[unlikely]] {
-        throw std::invalid_argument(absl::StrFormat("Expected list, got %s.", py::repr(object)));
+        throw std::invalid_argument(
+            absl::StrFormat("Expected an instance of list, got %s.", py::repr(object)));
     }
 }
 template <>
 inline void AssertExact<py::tuple>(const py::handle& object) {
     if (!PyTuple_CheckExact(object.ptr())) [[unlikely]] {
-        throw std::invalid_argument(absl::StrFormat("Expected tuple, got %s.", py::repr(object)));
+        throw std::invalid_argument(
+            absl::StrFormat("Expected an instance of tuple, got %s.", py::repr(object)));
     }
 }
 template <>
 inline void AssertExact<py::dict>(const py::handle& object) {
     if (!PyDict_CheckExact(object.ptr())) [[unlikely]] {
-        throw std::invalid_argument(absl::StrFormat("Expected dict, got %s.", py::repr(object)));
+        throw std::invalid_argument(
+            absl::StrFormat("Expected an instance of dict, got %s.", py::repr(object)));
     }
 }
 
@@ -357,29 +360,29 @@ inline bool IsNamedTupleClass(const py::handle& type) {
 inline bool IsNamedTuple(const py::handle& object) { return IsNamedTupleClass(object.get_type()); }
 inline void AssertExactNamedTuple(const py::handle& object) {
     if (!IsNamedTuple(object)) [[unlikely]] {
-        throw std::invalid_argument(
-            absl::StrFormat("Expected collections.namedtuple, got %s.", py::repr(object)));
+        throw std::invalid_argument(absl::StrFormat(
+            "Expected an instance of collections.namedtuple, got %s.", py::repr(object)));
     }
 }
 
 inline void AssertExactOrderedDict(const py::handle& object) {
     if (!object.get_type().is(PyOrderedDictTypeObject)) [[unlikely]] {
-        throw std::invalid_argument(
-            absl::StrFormat("Expected collections.OrderedDict, got %s.", py::repr(object)));
+        throw std::invalid_argument(absl::StrFormat(
+            "Expected an instance of collections.OrderedDict, got %s.", py::repr(object)));
     }
 }
 
 inline void AssertExactDefaultDict(const py::handle& object) {
     if (!object.get_type().is(PyDefaultDictTypeObject)) [[unlikely]] {
-        throw std::invalid_argument(
-            absl::StrFormat("Expected collections.defaultdict, got %s.", py::repr(object)));
+        throw std::invalid_argument(absl::StrFormat(
+            "Expected an instance of collections.defaultdict, got %s.", py::repr(object)));
     }
 }
 
 inline void AssertExactDeque(const py::handle& object) {
     if (!object.get_type().is(PyDequeTypeObject)) [[unlikely]] {
-        throw std::invalid_argument(
-            absl::StrFormat("Expected collections.deque, got %s.", py::repr(object)));
+        throw std::invalid_argument(absl::StrFormat(
+            "Expected an instance of collections.deque, got %s.", py::repr(object)));
     }
 }
 
@@ -414,8 +417,8 @@ inline bool IsStructSequence(const py::handle& object) {
 }
 inline void AssertExactStructSequence(const py::handle& object) {
     if (!IsStructSequence(object)) [[unlikely]] {
-        throw std::invalid_argument(
-            absl::StrFormat("Expected StructSequence, got %s.", py::repr(object)));
+        throw std::invalid_argument(absl::StrFormat(
+            "Expected an instance of StructSequence type, got %s.", py::repr(object)));
     }
 }
 inline py::tuple StructSequenceGetFields(const py::handle& object) {
@@ -424,7 +427,7 @@ inline py::tuple StructSequenceGetFields(const py::handle& object) {
         type = object;
         if (!IsStructSequenceClass(type)) [[unlikely]] {
             throw std::invalid_argument(
-                absl::StrFormat("Expected StructSequence type, got %s.", py::repr(object)));
+                absl::StrFormat("Expected a StructSequence type, got %s.", py::repr(object)));
         }
     } else {
         type = object.get_type();

--- a/optree/__init__.py
+++ b/optree/__init__.py
@@ -121,7 +121,7 @@ __all__ = [
 ]
 
 MAX_RECURSION_DEPTH: int = MAX_RECURSION_DEPTH
-"""Maximum recursion depth for pytree traversal. It is 5000 on Unix systems and 2500 on Windows."""
+"""Maximum recursion depth for pytree traversal. It is 5000 on Unix-like systems and 2500 on Windows."""
 NONE_IS_NODE: bool = NONE_IS_NODE  # literal constant
 """Literal constant that treats :data:`None` as a pytree non-leaf node."""
 NONE_IS_LEAF: bool = NONE_IS_LEAF  # literal constant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,9 @@ typing-modules = ["optree.typing"]
 "setup.py" = [
     "ANN",   # flake8-annotations
 ]
+"benchmark.py" = [
+    "PLW2901",  # redefined-loop-name
+]
 
 [tool.ruff.flake8-annotations]
 allow-star-arg-any = true

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -608,9 +608,8 @@ py::object PyTreeSpec::ToPicklable() const {
                 }
             }
             if (node.custom == nullptr) [[unlikely]] {
-                throw std::runtime_error(absl::StrCat("Unknown custom type in pickled PyTreeSpec: ",
-                                                      static_cast<std::string>(py::repr(t[4])),
-                                                      "."));
+                throw std::runtime_error(absl::StrFormat(
+                    "Unknown custom type in pickled PyTreeSpec: %s.", py::repr(t[4])));
             }
         } else if (!t[3].is_none() || !t[4].is_none()) [[unlikely]] {
             throw std::runtime_error("Malformed pickled PyTreeSpec.");

--- a/src/treespec/unflatten.cpp
+++ b/src/treespec/unflatten.cpp
@@ -36,10 +36,10 @@ py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
             case PyTreeKind::Leaf: {
                 if (node.kind == PyTreeKind::Leaf || m_none_is_leaf) [[likely]] {
                     if (it == leaves.end()) [[unlikely]] {
-                        throw std::invalid_argument(
-                            absl::StrFormat("Too few leaves for PyTreeSpec; expected %ld, got %ld.",
-                                            num_leaves(),
-                                            leaf_count));
+                        throw std::invalid_argument(absl::StrFormat(
+                            "Too few leaves for PyTreeSpec; expected: %ld, got: %ld.",
+                            num_leaves(),
+                            leaf_count));
                     }
                     agenda.emplace_back(py::reinterpret_borrow<py::object>(*it));
                     ++it;
@@ -75,7 +75,7 @@ py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
     }
     if (it != leaves.end()) [[unlikely]] {
         throw std::invalid_argument(
-            absl::StrFormat("Too many leaves for PyTreeSpec; expected %ld.", num_leaves()));
+            absl::StrFormat("Too many leaves for PyTreeSpec; expected: %ld.", num_leaves()));
     }
     EXPECT_EQ(agenda.size(), 1, "PyTreeSpec traversal did not yield a singleton.");
     return std::move(agenda.back());

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -74,11 +74,11 @@ def test_max_depth():
 
     l = [l]
     with pytest.raises(
-        RecursionError, match='maximum recursion depth exceeded during flattening the tree'
+        RecursionError, match='Maximum recursion depth exceeded during flattening the tree.'
     ):
         optree.tree_flatten(l)
     with pytest.raises(
-        RecursionError, match='maximum recursion depth exceeded during flattening the tree'
+        RecursionError, match='Maximum recursion depth exceeded during flattening the tree.'
     ):
         optree.tree_flatten_with_path(l)
 
@@ -633,7 +633,7 @@ def test_broadcast_prefix():
     assert optree.broadcast_prefix(1, [1, 2, 3]) == [1, 1, 1]
     assert optree.broadcast_prefix([1, 2, 3], [1, 2, 3]) == [1, 2, 3]
     with pytest.raises(
-        ValueError, match=re.escape('List arity mismatch: 4 != 3; list: [1, 2, 3, 4].')
+        ValueError, match=re.escape('list arity mismatch; expected: 3, got: 4; list: [1, 2, 3, 4].')
     ):
         optree.broadcast_prefix([1, 2, 3], [1, 2, 3, 4])
     assert optree.broadcast_prefix([1, 2, 3], [1, 2, (3, 4)]) == [1, 2, 3, 3]

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -144,44 +144,46 @@ def test_structseq_fields():
 
     with pytest.raises(
         ValueError,
-        match=re.escape(r'Expected StructSequence, got [1, 2].'),
+        match=re.escape(r'Expected an instance of StructSequence type, got [1, 2].'),
     ):
         optree.structseq_fields([1, 2])
     with pytest.raises(
         ValueError,
-        match=re.escape(r"Expected StructSequence type, got <class 'list'>."),
+        match=re.escape(r"Expected a StructSequence type, got <class 'list'>."),
     ):
         optree.structseq_fields(list)
 
     with pytest.raises(
         ValueError,
-        match=re.escape(r'Expected StructSequence, got (1, 2).'),
+        match=re.escape(r'Expected an instance of StructSequence type, got (1, 2).'),
     ):
         optree.structseq_fields((1, 2))
     with pytest.raises(
         ValueError,
-        match=re.escape(r"Expected StructSequence type, got <class 'tuple'>."),
+        match=re.escape(r"Expected a StructSequence type, got <class 'tuple'>."),
     ):
         optree.structseq_fields(tuple)
 
     with pytest.raises(
         ValueError,
-        match=re.escape(r'Expected StructSequence, got CustomTuple(foo=1, bar=2).'),
+        match=re.escape(
+            r'Expected an instance of StructSequence type, got CustomTuple(foo=1, bar=2).'
+        ),
     ):
         optree.structseq_fields(CustomTuple(1, 2))
     with pytest.raises(
         ValueError,
-        match=re.escape(r"Expected StructSequence type, got <class 'helpers.CustomTuple'>."),
+        match=re.escape(r"Expected a StructSequence type, got <class 'helpers.CustomTuple'>."),
     ):
         optree.structseq_fields(CustomTuple)
 
     with pytest.raises(
         ValueError,
-        match=re.escape(r'Expected StructSequence, got (1, 2).'),
+        match=re.escape(r'Expected an instance of StructSequence type, got (1, 2).'),
     ):
         optree.structseq_fields(FakeStructSequence((1, 2)))
     with pytest.raises(
         ValueError,
-        match=r"Expected StructSequence type, got <class '.*\.FakeStructSequence'>\.",
+        match=r"Expected a StructSequence type, got <class '.*\.FakeStructSequence'>\.",
     ):
         optree.structseq_fields(FakeStructSequence)


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
