### PR TITLE
perf(flatten_up_to): test dict key equality with `PyDict_Contains`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Test dict key equality with `PyDict_Contains` ($O (n)$) rather than sorting ($O (n \log n)$) by [@XuehaiPan](https://github.com/XuehaiPan) in [#37](https://github.com/metaopt/optree/pull/37).
 - Make error message more clear when value mismatch by [@XuehaiPan](https://github.com/XuehaiPan) in [#36](https://github.com/metaopt/optree/pull/36).
 - Add `ruff` and `flake8` plugins integration by [@XuehaiPan](https://github.com/XuehaiPan) in [#33](https://github.com/metaopt/optree/pull/33) and [#34](https://github.com/metaopt/optree/pull/34).
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -455,3 +455,14 @@ inline bool DictKeysEqual(const py::list& /* unique */ keys, const py::dict& dic
     }
     return true;
 }
+
+inline std::pair<py::list, py::list> DictKeysDifference(const py::list& /* unique */ keys,
+                                                        const py::dict& dict) {
+    py::set expected_keys{keys};
+    py::set got_keys{DictKeys(dict)};
+    py::list missing_keys{expected_keys - got_keys};
+    py::list extra_keys{got_keys - expected_keys};
+    TotalOrderSort(missing_keys);
+    TotalOrderSort(extra_keys);
+    return {missing_keys, extra_keys};
+}

--- a/include/utils.h
+++ b/include/utils.h
@@ -81,52 +81,6 @@ inline std::vector<T> reserved_vector(const size_t& size) {
     return v;
 }
 
-inline void TotalOrderSort(py::list& list) {  // NOLINT[runtime/references]
-    try {
-        // Sort directly if possible.
-        // NOLINTNEXTLINE[readability-implicit-bool-conversion]
-        if (PyList_Sort(list.ptr())) [[unlikely]] {
-            throw py::error_already_set();
-        }
-    } catch (py::error_already_set& ex1) {
-        if (ex1.matches(PyExc_TypeError)) [[likely]] {
-            // Found incomparable keys (e.g. `int` vs. `str`, or user-defined types).
-            try {
-                // Sort with `(f'{o.__class__.__module__}.{o.__class__.__qualname__}', o)`
-                auto sort_key_fn = py::cpp_function([](const py::object& o) {
-                    py::handle t = o.get_type();
-                    py::str qualname{absl::StrFormat(
-                        "%s.%s",
-                        static_cast<std::string>(py::getattr(t, "__module__").cast<py::str>()),
-                        static_cast<std::string>(py::getattr(t, "__qualname__").cast<py::str>()))};
-                    return py::make_tuple(qualname, o);
-                });
-                list.attr("sort")(py::arg("key") = sort_key_fn);
-            } catch (py::error_already_set& ex2) {
-                if (ex2.matches(PyExc_TypeError)) [[likely]] {
-                    // Found incomparable user-defined key types.
-                    // The keys remain in the insertion order.
-                    PyErr_Clear();
-                } else [[unlikely]] {
-                    throw;
-                }
-            }
-        } else [[unlikely]] {
-            throw;
-        }
-    }
-}
-
-inline py::list DictKeys(const py::dict& dict) {
-    return py::reinterpret_steal<py::list>(PyDict_Keys(dict.ptr()));
-}
-
-inline py::list SortedDictKeys(const py::dict& dict) {
-    py::list keys = DictKeys(dict);
-    TotalOrderSort(keys);
-    return keys;
-}
-
 template <typename Sized = py::object>
 inline ssize_t GetSize(const py::handle& sized) {
     return py::ssize_t_cast(py::len(sized));
@@ -156,17 +110,10 @@ template <>
 inline ssize_t GET_SIZE<py::list>(const py::handle& sized) {
     return PyList_GET_SIZE(sized.ptr());
 }
-#ifdef PyDict_GET_SIZE
 template <>
 inline ssize_t GET_SIZE<py::dict>(const py::handle& sized) {
     return PyDict_GET_SIZE(sized.ptr());
 }
-#else
-template <>
-inline ssize_t GET_SIZE<py::dict>(const py::handle& sized) {
-    return PyDict_Size(sized.ptr());
-}
-#endif
 
 template <typename Container, typename Item>
 inline py::handle GET_ITEM_HANDLE(const py::handle& container, const Item& item) {
@@ -442,4 +389,69 @@ inline py::tuple StructSequenceGetFields(const py::handle& object) {
         SET_ITEM<py::tuple>(fields, i, py::str(members[i].name));
     }
     return fields;
+}
+
+inline void TotalOrderSort(py::list& list) {  // NOLINT[runtime/references]
+    try {
+        // Sort directly if possible.
+        // NOLINTNEXTLINE[readability-implicit-bool-conversion]
+        if (PyList_Sort(list.ptr())) [[unlikely]] {
+            throw py::error_already_set();
+        }
+    } catch (py::error_already_set& ex1) {
+        if (ex1.matches(PyExc_TypeError)) [[likely]] {
+            // Found incomparable keys (e.g. `int` vs. `str`, or user-defined types).
+            try {
+                // Sort with `(f'{o.__class__.__module__}.{o.__class__.__qualname__}', o)`
+                auto sort_key_fn = py::cpp_function([](const py::object& o) {
+                    py::handle t = o.get_type();
+                    py::str qualname{absl::StrFormat(
+                        "%s.%s",
+                        static_cast<std::string>(py::getattr(t, "__module__").cast<py::str>()),
+                        static_cast<std::string>(py::getattr(t, "__qualname__").cast<py::str>()))};
+                    return py::make_tuple(qualname, o);
+                });
+                list.attr("sort")(py::arg("key") = sort_key_fn);
+            } catch (py::error_already_set& ex2) {
+                if (ex2.matches(PyExc_TypeError)) [[likely]] {
+                    // Found incomparable user-defined key types.
+                    // The keys remain in the insertion order.
+                    PyErr_Clear();
+                } else [[unlikely]] {
+                    throw;
+                }
+            }
+        } else [[unlikely]] {
+            throw;
+        }
+    }
+}
+
+inline py::list DictKeys(const py::dict& dict) {
+    return py::reinterpret_steal<py::list>(PyDict_Keys(dict.ptr()));
+}
+
+inline py::list SortedDictKeys(const py::dict& dict) {
+    py::list keys = DictKeys(dict);
+    TotalOrderSort(keys);
+    return keys;
+}
+
+inline bool DictKeysEqual(const py::list& /* unique */ keys, const py::dict& dict) {
+    ssize_t list_len = GET_SIZE<py::list>(keys);
+    ssize_t dict_len = GET_SIZE<py::dict>(dict);
+    if (list_len != dict_len) [[likely]] {  // assumes keys are unique
+        return false;
+    }
+    for (ssize_t i = 0; i < list_len; ++i) {
+        py::object key = GET_ITEM_BORROW<py::list>(keys, i);
+        int result = PyDict_Contains(dict.ptr(), key.ptr());
+        if (result == -1) [[unlikely]] {
+            throw py::error_already_set();
+        }
+        if (result == 0) [[likely]] {
+            return false;
+        }
+    }
+    return true;
 }

--- a/src/treespec/flatten.cpp
+++ b/src/treespec/flatten.cpp
@@ -494,7 +494,7 @@ py::list PyTreeSpec::FlattenUpToImpl(const py::handle& full_tree) const {
                     if (keys.not_equal(expected_keys)) [[unlikely]] {
                         throw std::invalid_argument(
                             absl::StrFormat("OrderedDict key mismatch; "
-                                            "expected keys: %s, got keys: %s; OrderedDict: %s.",
+                                            "expected key(s): %s, got key(s): %s; OrderedDict: %s.",
                                             py::repr(expected_keys),
                                             py::repr(keys),
                                             py::repr(object)));
@@ -502,7 +502,8 @@ py::list PyTreeSpec::FlattenUpToImpl(const py::handle& full_tree) const {
                 } else if (!DictKeysEqual(expected_keys, dict)) [[unlikely]] {
                     py::list keys = SortedDictKeys(dict);
                     throw std::invalid_argument(
-                        absl::StrFormat("%s key mismatch; expected keys: %s, got keys: %s; %s: %s.",
+                        absl::StrFormat("%s key mismatch; "
+                                        "expected key(s): %s, got key(s): %s; %s: %s.",
                                         (node.kind == PyTreeKind::Dict ? "dict" : "defaultdict"),
                                         py::repr(expected_keys),
                                         py::repr(keys),

--- a/tests/test_prefix_errors.py
+++ b/tests/test_prefix_errors.py
@@ -150,7 +150,7 @@ def test_different_num_children_multiple():
 def test_different_metadata():
     lhs, rhs = {1: 2}, {3: 4}
     with pytest.raises(
-        ValueError, match=r'dict key mismatch; expected keys: .*, got keys: .*; dict: .*\.'
+        ValueError, match=r'dict key mismatch; expected key\(s\): .*, got key\(s\): .*; dict: .*\.'
     ):
         optree.tree_map_(lambda x, y: None, lhs, rhs)
 
@@ -164,7 +164,7 @@ def test_different_metadata():
     lhs, rhs = OrderedDict({'a': 1, 'b': 2}), OrderedDict({'a': 3, 'c': 4})
     with pytest.raises(
         ValueError,
-        match=r'OrderedDict key mismatch; expected keys: .*, got keys: .*; OrderedDict: .*\.',
+        match=r'OrderedDict key mismatch; expected key\(s\): .*, got key\(s\): .*; OrderedDict: .*\.',
     ):
         optree.tree_map_(lambda x, y: None, lhs, rhs)
 
@@ -178,7 +178,7 @@ def test_different_metadata():
     lhs, rhs = OrderedDict({'a': 1, 'b': 2}), OrderedDict({'b': 4, 'a': 3})
     with pytest.raises(
         ValueError,
-        match=r'OrderedDict key mismatch; expected keys: .*, got keys: .*; OrderedDict: .*\.',
+        match=r'OrderedDict key mismatch; expected key\(s\): .*, got key\(s\): .*; OrderedDict: .*\.',
     ):
         optree.tree_map_(lambda x, y: None, lhs, rhs)
 
@@ -207,7 +207,7 @@ def test_different_metadata():
 def test_different_metadata_nested():
     lhs, rhs = [{1: 2}], [{3: 4}]
     with pytest.raises(
-        ValueError, match=r'dict key mismatch; expected keys: .*, got keys: .*; dict: .*\.'
+        ValueError, match=r'dict key mismatch; expected key\(s\): .*, got key\(s\): .*; dict: .*\.'
     ):
         optree.tree_map_(lambda x, y: None, lhs, rhs)
 
@@ -222,7 +222,7 @@ def test_different_metadata_nested():
 def test_different_metadata_multiple():
     lhs, rhs = [{1: 2}, {3: 4}], [{3: 4}, {5: 6}]
     with pytest.raises(
-        ValueError, match=r'dict key mismatch; expected keys: .*, got keys: .*; dict: .*\.'
+        ValueError, match=r'dict key mismatch; expected key\(s\): .*, got key\(s\): .*; dict: .*\.'
     ):
         optree.tree_map_(lambda x, y: None, lhs, rhs)
 

--- a/tests/test_prefix_errors.py
+++ b/tests/test_prefix_errors.py
@@ -34,7 +34,33 @@ from optree.registry import (
 
 
 def test_different_types():
-    (e,) = optree.prefix_errors((1, 2), [1, 2])
+    lhs, rhs = (1, 2), [1, 2]
+    with pytest.raises(ValueError, match=r'Expected an instance of .*, got .*\.'):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
+    expected = re.escape(
+        'pytree structure error: different types at key path\n' '    in_axes tree root'
+    )
+    with pytest.raises(ValueError, match=expected):
+        raise e('in_axes')
+
+    lhs, rhs = {'a': 1, 'b': 2}, OrderedDict({'a': 1, 'b': 2})
+    with pytest.raises(ValueError, match=r'Expected an instance of .*, got .*\.'):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
+    expected = re.escape(
+        'pytree structure error: different types at key path\n' '    in_axes tree root'
+    )
+    with pytest.raises(ValueError, match=expected):
+        raise e('in_axes')
+
+    lhs, rhs = {'a': 1, 'b': 2}, defaultdict(int, {'a': 1, 'b': 2})
+    with pytest.raises(ValueError, match=r'Expected an instance of .*, got .*\.'):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different types at key path\n' '    in_axes tree root'
     )
@@ -43,14 +69,22 @@ def test_different_types():
 
 
 def test_different_types_nested():
-    (e,) = optree.prefix_errors(((1,), (2,)), ([3], (4,)))
+    lhs, rhs = ((1,), (2,)), ([3], (4,))
+    with pytest.raises(ValueError, match=r'Expected an instance of .*, got .*\.'):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape('pytree structure error: different types at key path\n' '    in_axes[0]')
     with pytest.raises(ValueError, match=expected):
         raise e('in_axes')
 
 
 def test_different_types_multiple():
-    e1, e2 = optree.prefix_errors(((1,), (2,)), ([3], [4]))
+    lhs, rhs = ((1,), (2,)), ([3], [4])
+    with pytest.raises(ValueError, match=r'Expected an instance of .*, got .*\.'):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    e1, e2 = optree.prefix_errors(lhs, rhs)
     expected = re.escape('pytree structure error: different types at key path\n' '    in_axes[0]')
     with pytest.raises(ValueError, match=expected):
         raise e1('in_axes')
@@ -60,7 +94,13 @@ def test_different_types_multiple():
 
 
 def test_different_num_children():
-    (e,) = optree.prefix_errors((1,), (2, 3))
+    lhs, rhs = (1,), (2, 3)
+    with pytest.raises(
+        ValueError, match=r'tuple arity mismatch; expected: \d+, got: \d+; tuple: .*\.'
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different numbers of pytree children at key path\n'
         '    in_axes tree root'
@@ -70,7 +110,13 @@ def test_different_num_children():
 
 
 def test_different_num_children_nested():
-    (e,) = optree.prefix_errors([[1]], [[2, 3]])
+    lhs, rhs = [[1]], [[2, 3]]
+    with pytest.raises(
+        ValueError, match=r'list arity mismatch; expected: \d+, got: \d+; list: .*\.'
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different numbers of pytree children at key path\n'
         '    in_axes[0]'
@@ -80,7 +126,13 @@ def test_different_num_children_nested():
 
 
 def test_different_num_children_multiple():
-    e1, e2 = optree.prefix_errors([[1], [2]], [[3, 4], [5, 6]])
+    lhs, rhs = [[1], [2]], [[3, 4], [5, 6]]
+    with pytest.raises(
+        ValueError, match=r'list arity mismatch; expected: \d+, got: \d+; list: .*\.'
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    e1, e2 = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different numbers of pytree children at key path\n'
         '    in_axes[0]'
@@ -96,7 +148,55 @@ def test_different_num_children_multiple():
 
 
 def test_different_metadata():
-    (e,) = optree.prefix_errors({1: 2}, {3: 4})
+    lhs, rhs = {1: 2}, {3: 4}
+    with pytest.raises(
+        ValueError, match=r'dict key mismatch; expected keys: .*, got keys: .*; dict: .*\.'
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
+    expected = re.escape(
+        'pytree structure error: different pytree metadata at key path\n' '    in_axes tree root'
+    )
+    with pytest.raises(ValueError, match=expected):
+        raise e('in_axes')
+
+    lhs, rhs = OrderedDict({'a': 1, 'b': 2}), OrderedDict({'a': 3, 'c': 4})
+    with pytest.raises(
+        ValueError,
+        match=r'OrderedDict key mismatch; expected keys: .*, got keys: .*; OrderedDict: .*\.',
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
+    expected = re.escape(
+        'pytree structure error: different pytree metadata at key path\n' '    in_axes tree root'
+    )
+    with pytest.raises(ValueError, match=expected):
+        raise e('in_axes')
+
+    lhs, rhs = OrderedDict({'a': 1, 'b': 2}), OrderedDict({'b': 4, 'a': 3})
+    with pytest.raises(
+        ValueError,
+        match=r'OrderedDict key mismatch; expected keys: .*, got keys: .*; OrderedDict: .*\.',
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
+    expected = re.escape(
+        'pytree structure error: different pytree metadata at key path\n' '    in_axes tree root'
+    )
+    with pytest.raises(ValueError, match=expected):
+        raise e('in_axes')
+
+    lhs, rhs = defaultdict(list, {'a': 1, 'b': 2}), defaultdict(set, {'b': 4, 'a': 3})
+    with pytest.raises(
+        ValueError,
+        match=r'defaultdict factory mismatch; expected factory: .*, got factory: .*; defaultdict: .*\.',
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different pytree metadata at key path\n' '    in_axes tree root'
     )
@@ -105,7 +205,13 @@ def test_different_metadata():
 
 
 def test_different_metadata_nested():
-    (e,) = optree.prefix_errors([{1: 2}], [{3: 4}])
+    lhs, rhs = [{1: 2}], [{3: 4}]
+    with pytest.raises(
+        ValueError, match=r'dict key mismatch; expected keys: .*, got keys: .*; dict: .*\.'
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different pytree metadata at key path\n' '    in_axes[0]'
     )
@@ -114,7 +220,13 @@ def test_different_metadata_nested():
 
 
 def test_different_metadata_multiple():
-    e1, e2 = optree.prefix_errors([{1: 2}, {3: 4}], [{3: 4}, {5: 6}])
+    lhs, rhs = [{1: 2}, {3: 4}], [{3: 4}, {5: 6}]
+    with pytest.raises(
+        ValueError, match=r'dict key mismatch; expected keys: .*, got keys: .*; dict: .*\.'
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    e1, e2 = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different pytree metadata at key path\n' '    in_axes[0]'
     )
@@ -128,7 +240,11 @@ def test_different_metadata_multiple():
 
 
 def test_namedtuple():
-    (e,) = optree.prefix_errors(CustomTuple(1, [2, [3]]), CustomTuple(4, [5, 6]))
+    lhs, rhs = CustomTuple(1, [2, [3]]), CustomTuple(4, [5, 6])
+    with pytest.raises(ValueError):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different types at key path\n' '    in_axes.bar[1]'
     )
@@ -137,9 +253,11 @@ def test_namedtuple():
 
 
 def test_structseq():
-    (e,) = optree.prefix_errors(
-        TimeStructTime((1, [2, [3]], *range(7))), TimeStructTime((4, [5, 6], *range(7)))
-    )
+    lhs, rhs = TimeStructTime((1, [2, [3]], *range(7))), TimeStructTime((4, [5, 6], *range(7)))
+    with pytest.raises(ValueError):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+
+    (e,) = optree.prefix_errors(lhs, rhs)
     expected = re.escape(
         'pytree structure error: different types at key path\n' '    in_axes.tm_mon[1]'
     )
@@ -157,7 +275,12 @@ def test_fallback_keypath():
 
 
 def test_no_errors():
-    () = optree.prefix_errors((1, 2), ((11, 12, 13), 2))
+    for lhs, rhs in (
+        ((1, 2), ((11, 12, 13), 2)),
+        ({'a': 1, 'b': 2}, {'b': (11, 12, 13), 'a': 2}),
+    ):
+        optree.tree_map_(lambda x, y: None, lhs, rhs)
+        () = optree.prefix_errors(lhs, rhs)
 
 
 def test_different_structure_no_children():


### PR DESCRIPTION
## Description

Describe your changes in detail.

Replace the sort-based comparison with `PyDict_Contains` in for-loops. This will reduce the time complexity for `dict` keys equality test from $O (n \log n)$ to $O (n)$.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
