### PR TITLE
fix(ops): align kwargs for `tree_reduce` with `functools.reduce` with the Python C implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: clang-format
         stages: [commit, push, manual]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.255
+    rev: v0.0.257
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Change keyword argument `initializer` back to `initial` for `tree_reduce` to align with `functools.reduce` C implementation by [@XuehaiPan](https://github.com/XuehaiPan) in [#47](https://github.com/metaopt/optree/pull/47).
 
 ### Fixed
 

--- a/optree/ops.py
+++ b/optree/ops.py
@@ -895,7 +895,7 @@ def tree_reduce(
 def tree_reduce(
     func: Callable[[T, T], T],
     tree: PyTree[T],
-    initializer: T = __MISSING,
+    initial: T = __MISSING,
     *,
     is_leaf: Callable[[T], bool] | None = None,
     none_is_leaf: bool = False,
@@ -907,7 +907,7 @@ def tree_reduce(
 def tree_reduce(
     func,
     tree,
-    initializer=__MISSING,
+    initial=__MISSING,
     *,
     is_leaf=None,
     none_is_leaf=False,
@@ -929,8 +929,8 @@ def tree_reduce(
     Args:
         func (callable): A function that takes two arguments and returns a value of the same type.
         tree (pytree): A pytree to be traversed.
-        initializer (object, optional): An initial value to be used for the reduction. If not
-            provided, the first leaf value is used as the initial value.
+        initial (object, optional): An initial value to be used for the reduction. If not provided,
+            the first leaf value is used as the initial value.
         is_leaf (callable, optional): An optionally specified function that will be called at each
             flattening step. It should return a boolean, with :data:`True` stopping the traversal
             and the whole subtree being treated as a leaf, and :data:`False` indicating the
@@ -946,9 +946,9 @@ def tree_reduce(
         The result of reducing the leaves of the pytree using ``func``.
     """  # pylint: disable=line-too-long
     leaves = tree_leaves(tree, is_leaf, none_is_leaf=none_is_leaf, namespace=namespace)
-    if initializer is __MISSING:
+    if initial is __MISSING:
         return functools.reduce(func, leaves)
-    return functools.reduce(func, leaves, initializer)
+    return functools.reduce(func, leaves, initial)
 
 
 def tree_sum(

--- a/optree/typing.py
+++ b/optree/typing.py
@@ -153,7 +153,7 @@ class PyTree(Generic[T]):  # pylint: disable=too-few-public-methods
     """
 
     @_tp_cache
-    def __class_getitem__(  # noqa: C901
+    def __class_getitem__(
         cls,
         item: T | tuple[T] | tuple[T, str | None],
     ) -> TypeAlias:


### PR DESCRIPTION
## Description

Describe your changes in detail.

The argument in `tree_reduce`  was changed from `initial` to `initializer` in #39. I realized this is a documentation issue in Python. The signature in Python C code is `initial`. This PR reverts the changes for the argument name in `tree_reduce`.

Ref:

- python/cpython#102757
- python/cpython#102759

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

- python/cpython#102757
- python/cpython#102759

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
