### PR TITLE
fix(typing): add `@runtime_checkable` decorator for `CustomTreeNode` protocol class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Add `@runtime_checkable` decorator for `CustomTreeNode` protocol class by [@XuehaiPan](https://github.com/XuehaiPan) in [#56](https://github.com/metaopt/optree/pull/56).
 
 ### Removed
 

--- a/optree/typing.py
+++ b/optree/typing.py
@@ -38,8 +38,8 @@ from typing import (
     Union,
 )
 from typing_extensions import OrderedDict  # Generic OrderedDict: Python 3.7.2+
-from typing_extensions import Protocol  # Python 3.8+
 from typing_extensions import TypeAlias  # Python 3.10+
+from typing_extensions import Protocol, runtime_checkable  # Python 3.8+
 
 from optree import _C
 
@@ -99,6 +99,7 @@ _MetaData = TypeVar('_MetaData', bound=Hashable)
 MetaData = Optional[_MetaData]
 
 
+@runtime_checkable
 class CustomTreeNode(Protocol[T]):
     """The abstract base class for custom pytree nodes."""
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

Add `@runtime_checkable` decorator for `CustomTreeNode` protocol class.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Fix CI failure since `typing-extensions` 4.6.0 was released.

Refs:

- python/typing_extensions#161
- python/cpython#26067
- python/typing_extensions#132
- python/typing_extensions#134
- python/typing_extensions#178

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
