### PR TITLE
fix(ops): fix empty paths when flatten with custom `is_leaf` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix empty paths when flatten with custom `is_leaf` function by [@XuehaiPan](https://github.com/XuehaiPan) in [#76](https://github.com/metaopt/optree/pull/76).
 
 ### Removed
 

--- a/src/treespec/flatten.cpp
+++ b/src/treespec/flatten.cpp
@@ -208,7 +208,12 @@ bool PyTreeSpec::FlattenIntoWithPathImpl(const py::handle& handle,
     ssize_t start_num_nodes = py::ssize_t_cast(m_traversal.size());
     ssize_t start_num_leaves = py::ssize_t_cast(leaves.size());
     if (leaf_predicate && (*leaf_predicate)(handle).cast<bool>()) [[unlikely]] {
+        py::tuple path{depth};
+        for (ssize_t d = 0; d < depth; ++d) {
+            SET_ITEM<py::tuple>(path, d, stack[d]);
+        }
         leaves.emplace_back(py::reinterpret_borrow<py::object>(handle));
+        paths.emplace_back(std::move(path));
     } else [[likely]] {
         node.kind = GetKind<NoneIsLeaf>(handle, &node.custom, registry_namespace);
         // NOLINTNEXTLINE[misc-no-recursion]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -336,6 +336,42 @@ def test_paths(data):
     none_is_leaf=[False, True],
     namespace=['', 'undefined', 'namespace'],
 )
+def test_paths_with_is_leaf(tree, is_leaf, none_is_leaf, namespace):
+    expected_leaves, expected_treespec = optree.tree_flatten(
+        tree,
+        is_leaf=is_leaf,
+        none_is_leaf=none_is_leaf,
+        namespace=namespace,
+    )
+    paths, leaves, treespec = optree.tree_flatten_with_path(
+        tree,
+        is_leaf=is_leaf,
+        none_is_leaf=none_is_leaf,
+        namespace=namespace,
+    )
+    treespec_paths = optree.treespec_paths(treespec)
+    assert len(paths) == len(leaves)
+    assert leaves == expected_leaves
+    assert treespec == expected_treespec
+    assert len(treespec_paths) == len(leaves)
+    assert paths == treespec_paths
+    paths = optree.tree_paths(tree, is_leaf=is_leaf, none_is_leaf=none_is_leaf, namespace=namespace)
+    assert len(paths) == len(leaves)
+    assert paths == treespec_paths
+
+
+@parametrize(
+    tree=TREES,
+    is_leaf=[
+        is_tuple,
+        is_list,
+        is_none,
+        always,
+        never,
+    ],
+    none_is_leaf=[False, True],
+    namespace=['', 'undefined', 'namespace'],
+)
 def test_round_trip_is_leaf(tree, is_leaf, none_is_leaf, namespace):
     subtrees, treespec = optree.tree_flatten(
         tree,


### PR DESCRIPTION
## Description

Describe your changes in detail.

This PR adds the missing procedure to add the current path into the `paths` result.
The process is the same as the switch case for `PyTreeKind::Leaf`.

https://github.com/metaopt/optree/blob/d1e85f8975f132968e23fa70406d7353adb84155/src/treespec/flatten.cpp#L234-L242

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Fixes #75.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
