### PR TITLE
deps(pybind11): bump pybind11 version to 2.11.1 and add initial Python 3.12 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     timeout-minutes: 30
     steps:
@@ -103,6 +103,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           update-environment: true
+          allow-prereleases: true
 
       - name: Upgrade pip
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump `pybind11` version to 2.11.1 and add initial Python 3.12 support by [@XuehaiPan](https://github.com/XuehaiPan) in [#78](https://github.com/metaopt/optree/pull/78).
 - Bump `abseil-cpp` version to 20230802.0 by [@XuehaiPan](https://github.com/XuehaiPan) in [#79](https://github.com/metaopt/optree/pull/79).
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 
 system(
     STRIP OUTPUT_VARIABLE PYTHON_VERSION
-    COMMAND "${PYTHON_EXECUTABLE}" -c "print(__import__('platform').python_version())"
+    COMMAND "${PYTHON_EXECUTABLE}" -c "print('.'.join(map(str, __import__('sys').version_info[:3])))"
 )
 
 message(STATUS "Use Python version: ${PYTHON_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.11)  # for FetchContent
 project(optree LANGUAGES CXX)
 
 include(FetchContent)
-set(PYBIND11_VERSION v2.10.4)
+set(PYBIND11_VERSION v2.11.1)
 set(ABSEIL_CPP_VERSION 20230802.0)
 set(THIRD_PARTY_DIR "${CMAKE_SOURCE_DIR}/third-party")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX :: Linux",
     "Operating System :: MacOS",

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -907,16 +907,16 @@ def test_tree_sum():
 
 
 def test_tree_max():
-    with pytest.raises(ValueError, match=re.escape('max() arg is an empty sequence')):
+    with pytest.raises(ValueError, match='empty'):
         optree.tree_max({})
     assert optree.tree_max({}, default=0) == 0
     assert optree.tree_max({'x': 0, 'y': (2, 1)}) == 2
     assert optree.tree_max({'x': 0, 'y': (2, 1)}, key=lambda x: -x) == 0
-    with pytest.raises(ValueError, match=re.escape('max() arg is an empty sequence')):
+    with pytest.raises(ValueError, match='empty'):
         optree.tree_max({'a': None})
     assert optree.tree_max({'a': None}, default=0) == 0
     assert optree.tree_max({'a': None}, none_is_leaf=True) is None
-    with pytest.raises(ValueError, match=re.escape('max() arg is an empty sequence')):
+    with pytest.raises(ValueError, match='empty'):
         optree.tree_max(None)
     assert optree.tree_max(None, default=0) == 0
     assert optree.tree_max(None, none_is_leaf=True) is None
@@ -926,16 +926,16 @@ def test_tree_max():
 
 
 def test_tree_min():
-    with pytest.raises(ValueError, match=re.escape('min() arg is an empty sequence')):
+    with pytest.raises(ValueError, match='empty'):
         optree.tree_min({})
     assert optree.tree_min({}, default=0) == 0
     assert optree.tree_min({'x': 0, 'y': (2, 1)}) == 0
     assert optree.tree_min({'x': 0, 'y': (2, 1)}, key=lambda x: -x) == 2
-    with pytest.raises(ValueError, match=re.escape('min() arg is an empty sequence')):
+    with pytest.raises(ValueError, match='empty'):
         optree.tree_min({'a': None})
     assert optree.tree_min({'a': None}, default=0) == 0
     assert optree.tree_min({'a': None}, none_is_leaf=True) is None
-    with pytest.raises(ValueError, match=re.escape('min() arg is an empty sequence')):
+    with pytest.raises(ValueError, match='empty'):
         optree.tree_min(None)
     assert optree.tree_min(None, default=0) == 0
     assert optree.tree_min(None, none_is_leaf=True) is None


### PR DESCRIPTION
## Description

Describe your changes in detail.

- bump pybind11 version to 2.11.1
- add initial Python 3.12 support

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
