### PR TITLE
fix(treespec): memorize ongoing `repr` / `hash` calls to resolve infinite recursion under self-referential case

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: clang-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.290
+    rev: v0.0.291
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.12.0
+    rev: v3.13.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Memorize ongoing `repr` / `hash` calls to resolve infinite recursion under self-referential case by [@XuehaiPan](https://github.com/XuehaiPan) in [#82](https://github.com/metaopt/optree/pull/82).
+- Memorize ongoing `repr` / `hash` calls to resolve infinite recursion under self-referential case by [@XuehaiPan](https://github.com/XuehaiPan) and [@JieRen98](https://github.com/JieRen98) in [#82](https://github.com/metaopt/optree/pull/82).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Memorize ongoing `repr` / `hash` calls to resolve infinite recursion under self-referential case by [@XuehaiPan](https://github.com/XuehaiPan) in [#82](https://github.com/metaopt/optree/pull/82).
 
 ### Removed
 

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -227,7 +227,7 @@ class PyTreeSpec {
             return hash;
         } catch (...) {
             sm_hash_running.erase(indent);
-            throw;
+            std::rethrow_exception(std::current_exception());
         }
     }
 

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -26,7 +26,7 @@ limitations under the License.
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <thread>
+#include <thread>  // NOLINT[build/c++11]
 #include <tuple>
 #include <utility>
 #include <vector>

--- a/include/utils.h
+++ b/include/utils.h
@@ -457,11 +457,11 @@ inline void TotalOrderSort(py::list& list) {  // NOLINT[runtime/references]
                     // The keys remain in the insertion order.
                     PyErr_Clear();
                 } else [[unlikely]] {
-                    throw;
+                    std::rethrow_exception(std::current_exception());
                 }
             }
         } else [[unlikely]] {
-            throw;
+            std::rethrow_exception(std::current_exception());
         }
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,5 +29,6 @@ target_link_libraries(
     _C
     PUBLIC
     absl::flat_hash_map
+    absl::flat_hash_set
     absl::str_format
 )

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -710,7 +710,7 @@ std::string PyTreeSpec::ToString() const {
         return representation;
     } catch (...) {
         sm_repr_running.erase(indent);
-        throw;
+        std::rethrow_exception(std::current_exception());
     }
 }
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

Add a set to memorize ongoing `repr` / `hash` calls to resolve infinite recursion under self-referential case.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Fixes #81

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
