### PR TITLE
refactor: remove dependence on `abseil-cpp`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,6 @@
 # NOTE: there must be no spaces before the '-', so put the comma last.
 InheritParentConfig: true
 Checks: '
-abseil-*,
 bugprone-*,
 -bugprone-easily-swappable-parameters,
 clang-analyzer-*,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Decrease the `MAX_RECURSION_DEPTH` to 2000 on Windows by [@XuehaiPan](https://github.com/XuehaiPan) in [#85](https://github.com/metaopt/optree/pull/85).
 - Bump `abseil-cpp` version to 20230802.1 by [@XuehaiPan](https://github.com/XuehaiPan) in [#80](https://github.com/metaopt/optree/pull/80).
 
 ### Fixed
@@ -25,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
--
+- Remove dependence on `abseil-cpp` by [@XuehaiPan](https://github.com/XuehaiPan) in [#85](https://github.com/metaopt/optree/pull/85).
 
 ------
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,8 @@ set(THIRD_PARTY_DIR "${CMAKE_SOURCE_DIR}/third-party")
 if(NOT DEFINED PYBIND11_VERSION AND NOT "$ENV{PYBIND11_VERSION}" STREQUAL "")
     set(PYBIND11_VERSION "$ENV{PYBIND11_VERSION}")
 endif()
-if(NOT DEFINED ABSEIL_CPP_VERSION AND NOT "$ENV{ABSEIL_CPP_VERSION}" STREQUAL "")
-    set(ABSEIL_CPP_VERSION "$ENV{ABSEIL_CPP_VERSION}")
-endif()
 if(NOT PYBIND11_VERSION)
     set(PYBIND11_VERSION v2.11.1)
-endif()
-if(NOT ABSEIL_CPP_VERSION)
-    set(ABSEIL_CPP_VERSION 20230802.1)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -187,25 +181,6 @@ if("${PYBIND11_CMAKE_DIR}" STREQUAL "")
 else()
     message(STATUS "Detected Pybind11 CMake directory: \"${PYBIND11_CMAKE_DIR}\"")
     find_package(pybind11 CONFIG PATHS "${PYBIND11_CMAKE_DIR}")
-endif()
-
-# Include abseil-cpp
-set(ABSL_PROPAGATE_CXX_STD ON)
-set(ABSL_BUILD_TESTING OFF)
-FetchContent_Declare(
-    abseilcpp
-    GIT_REPOSITORY https://github.com/abseil/abseil-cpp.git
-    GIT_TAG "${ABSEIL_CPP_VERSION}"
-    GIT_SHALLOW TRUE
-    SOURCE_DIR "${THIRD_PARTY_DIR}/abseil-cpp"
-    BINARY_DIR "${THIRD_PARTY_DIR}/.cmake/abseil-cpp/build"
-    STAMP_DIR "${THIRD_PARTY_DIR}/.cmake/abseil-cpp/stamp"
-)
-FetchContent_GetProperties(abseilcpp)
-
-if(NOT abseilcpp_POPULATED)
-    message(STATUS "Populating Git repository abseil-cpp@${ABSEIL_CPP_VERSION} to third-party/abseil-cpp...")
-    FetchContent_MakeAvailable(abseilcpp)
 endif()
 
 include_directories("${CMAKE_SOURCE_DIR}")

--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -17,8 +17,7 @@ limitations under the License.
 
 #pragma once
 
-#include <absl/strings/str_format.h>
-
+#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -39,12 +38,13 @@ class InternalError : public std::logic_error {
  public:
     explicit InternalError(const std::string& msg) : std::logic_error(msg) {}
     InternalError(const std::string& msg, const std::string& file, const size_t& lineno)
-        : InternalError(absl::StrFormat(
-              "%s (at file %s:%lu)\n\n%s",
-              msg,
-              file,
-              lineno,
-              "Please file a bug report at https://github.com/metaopt/optree/issues.")) {}
+        : InternalError([&msg, &file, &lineno]() {
+              std::stringstream ss;
+              ss << msg << " (at file " << file << ":" << lineno << ")";
+              ss << std::endl << std::endl;
+              ss << "Please file a bug report at https://github.com/metaopt/optree/issues.";
+              return ss.str();
+          }()) {}
 };
 
 }  // namespace optree

--- a/include/registry.h
+++ b/include/registry.h
@@ -17,7 +17,6 @@ limitations under the License.
 
 #pragma once
 
-#include <absl/hash/hash.h>
 #include <pybind11/pybind11.h>
 
 #include <memory>
@@ -109,6 +108,8 @@ class PyTreeTypeRegistry {
         using is_transparent = void;
         bool operator()(const py::object &a, const py::object &b) const;
         bool operator()(const py::object &a, const py::handle &b) const;
+        bool operator()(const py::handle &a, const py::object &b) const;
+        bool operator()(const py::handle &a, const py::handle &b) const;
     };
 
     class NamedTypeHash {
@@ -123,6 +124,10 @@ class PyTreeTypeRegistry {
         bool operator()(const std::pair<std::string, py::object> &a,
                         const std::pair<std::string, py::object> &b) const;
         bool operator()(const std::pair<std::string, py::object> &a,
+                        const std::pair<std::string, py::handle> &b) const;
+        bool operator()(const std::pair<std::string, py::handle> &a,
+                        const std::pair<std::string, py::object> &b) const;
+        bool operator()(const std::pair<std::string, py::handle> &a,
                         const std::pair<std::string, py::handle> &b) const;
     };
 

--- a/include/registry.h
+++ b/include/registry.h
@@ -17,12 +17,12 @@ limitations under the License.
 
 #pragma once
 
-#include <absl/container/flat_hash_map.h>
 #include <absl/hash/hash.h>
 #include <pybind11/pybind11.h>
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "include/exceptions.h"
@@ -126,12 +126,11 @@ class PyTreeTypeRegistry {
                         const std::pair<std::string, py::handle> &b) const;
     };
 
-    absl::flat_hash_map<py::object, std::unique_ptr<Registration>, TypeHash, TypeEq>
-        m_registrations;
-    absl::flat_hash_map<std::pair<std::string, py::object>,
-                        std::unique_ptr<Registration>,
-                        NamedTypeHash,
-                        NamedTypeEq>
+    std::unordered_map<py::object, std::unique_ptr<Registration>, TypeHash, TypeEq> m_registrations;
+    std::unordered_map<std::pair<std::string, py::object>,
+                       std::unique_ptr<Registration>,
+                       NamedTypeHash,
+                       NamedTypeEq>
         m_named_registrations;
 };
 

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -18,7 +18,6 @@ limitations under the License.
 #pragma once
 
 #include <absl/container/flat_hash_set.h>
-#include <absl/container/inlined_vector.h>
 #include <absl/hash/hash.h>
 #include <pybind11/pybind11.h>
 
@@ -280,7 +279,7 @@ class PyTreeSpec {
 
     // Nodes, in a post-order traversal. We use an ordered traversal to minimize allocations, and
     // post-order corresponds to the order we need to rebuild the tree structure.
-    absl::InlinedVector<Node, 1> m_traversal;
+    std::vector<Node> m_traversal;
 
     // Whether to treat `None` as a leaf. If false, `None` is a non-leaf node with arity 0.
     bool m_none_is_leaf = false;

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -297,7 +297,9 @@ class PyTreeSpec {
         sm_hash_running{};
 
     // Helper that manufactures an instance of a node given its children.
-    static py::object MakeNode(const Node &node, const absl::Span<py::object> &children);
+    static py::object MakeNode(const Node &node,
+                               const py::object *children,
+                               const size_t &num_children);
 
     // Compute the node kind of a given Python object.
     template <bool NoneIsLeaf>

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -37,7 +37,7 @@ namespace optree {
 
 // The maximum depth of a pytree.
 #ifdef _WIN32
-constexpr ssize_t MAX_RECURSION_DEPTH = 2500;
+constexpr ssize_t MAX_RECURSION_DEPTH = 2000;
 #else
 constexpr ssize_t MAX_RECURSION_DEPTH = 5000;
 #endif

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -17,7 +17,6 @@ limitations under the License.
 
 #pragma once
 
-#include <absl/hash/hash.h>
 #include <pybind11/pybind11.h>
 
 #include <memory>
@@ -158,77 +157,7 @@ class PyTreeSpec {
     inline bool operator>=(const PyTreeSpec &other) const { return IsSuffix(other, false); }
 
     // Return the hash value of the PyTreeSpec.
-    template <typename H>
-    friend H AbslHashValue(H h, const Node &n) {
-        ssize_t data_hash = 0;
-        switch (n.kind) {
-            case PyTreeKind::Custom:
-                // We don't hash node_data custom node types since they may not hashable.
-                break;
-            case PyTreeKind::Leaf:
-            case PyTreeKind::None:
-            case PyTreeKind::Tuple:
-            case PyTreeKind::List:
-            case PyTreeKind::NamedTuple:
-            case PyTreeKind::Deque:
-            case PyTreeKind::StructSequence:
-                data_hash = py::hash(n.node_data ? n.node_data : py::none());
-                break;
-            case PyTreeKind::Dict:
-            case PyTreeKind::OrderedDict:
-            case PyTreeKind::DefaultDict: {
-                py::list keys;
-                if (n.kind == PyTreeKind::DefaultDict) [[unlikely]] {
-                    EXPECT_EQ(
-                        GET_SIZE<py::tuple>(n.node_data), 2, "Number of auxiliary data mismatch.");
-                    py::object default_factory = GET_ITEM_BORROW<py::tuple>(n.node_data, 0);
-                    keys = py::reinterpret_borrow<py::list>(
-                        GET_ITEM_BORROW<py::tuple>(n.node_data, 1));
-                    EXPECT_EQ(GET_SIZE<py::list>(keys),
-                              n.arity,
-                              "Number of keys and entries does not match.");
-                    data_hash = py::hash(default_factory);
-                } else [[likely]] {
-                    EXPECT_EQ(GET_SIZE<py::list>(n.node_data),
-                              n.arity,
-                              "Number of keys and entries does not match.");
-                    keys = py::reinterpret_borrow<py::list>(n.node_data);
-                }
-                for (const py::handle &&key : keys) {
-                    data_hash = py::ssize_t_cast(absl::HashOf(data_hash, py::hash(key)));
-                }
-                break;
-            }
-            default:
-                INTERNAL_ERROR();
-        }
-
-        return H::combine(
-            std::move(h), n.kind, n.arity, n.custom, n.num_leaves, n.num_nodes, data_hash);
-    }
-
-    template <typename H>
-    friend H AbslHashValueImpl(H h, const PyTreeSpec &t) {
-        return H::combine(std::move(h), t.m_traversal, t.m_none_is_leaf, t.m_namespace);
-    }
-
-    template <typename H>
-    friend H AbslHashValue(H h, const PyTreeSpec &t) {
-        std::pair<const PyTreeSpec *, std::thread::id> indent{&t, std::this_thread::get_id()};
-        if (sm_hash_running.contains(indent)) {
-            return h;
-        }
-
-        sm_hash_running.insert(indent);
-        try {
-            H hash = AbslHashValueImpl(std::move(h), t);
-            sm_hash_running.erase(indent);
-            return hash;
-        } catch (...) {
-            sm_hash_running.erase(indent);
-            std::rethrow_exception(std::current_exception());
-        }
-    }
+    [[nodiscard]] ssize_t HashValue() const;
 
     // Return a string representation of the PyTreeSpec.
     [[nodiscard]] std::string ToString() const;
@@ -327,6 +256,11 @@ class PyTreeSpec {
                                     Stack &stack,  // NOLINT[runtime/references]
                                     const ssize_t &pos,
                                     const ssize_t &depth) const;
+
+    // Get the hash value of the node.
+    static void HashCombineNode(ssize_t &seed, const Node &node);  // NOLINT[runtime/references]
+
+    [[nodiscard]] ssize_t HashValueImpl() const;
 
     [[nodiscard]] std::string ToStringImpl() const;
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -18,13 +18,12 @@ limitations under the License.
 #pragma once
 
 #include <Python.h>
-#include <absl/strings/str_format.h>
-#include <absl/strings/str_join.h>
 #include <pybind11/pybind11.h>
 #include <structmember.h>  // PyMemberDef
 
 #include <memory>
 #include <optional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <tuple>
@@ -265,43 +264,45 @@ inline void SET_ITEM<py::list>(const py::handle& container,
 template <typename PyType>
 inline void AssertExact(const py::handle& object) {
     if (!py::isinstance<PyType>(object)) [[unlikely]] {
-        throw py::value_error(absl::StrFormat(
-            "Expected an instance of %s, got %s.", typeid(PyType).name(), py::repr(object)));
+        std::stringstream ss;
+        ss << "Expected an instance of " << typeid(PyType).name() << ", got "
+           << static_cast<std::string>(py::repr(object)) << ".";
+        throw py::value_error(ss.str());
     }
 }
 template <>
 inline void AssertExact<py::list>(const py::handle& object) {
     if (!PyList_CheckExact(object.ptr())) [[unlikely]] {
-        throw py::value_error(
-            absl::StrFormat("Expected an instance of list, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of list, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 template <>
 inline void AssertExact<py::tuple>(const py::handle& object) {
     if (!PyTuple_CheckExact(object.ptr())) [[unlikely]] {
-        throw py::value_error(
-            absl::StrFormat("Expected an instance of tuple, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of tuple, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 template <>
 inline void AssertExact<py::dict>(const py::handle& object) {
     if (!PyDict_CheckExact(object.ptr())) [[unlikely]] {
-        throw py::value_error(
-            absl::StrFormat("Expected an instance of dict, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of dict, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 
 inline void AssertExactOrderedDict(const py::handle& object) {
     if (!py::type::handle_of(object).is(PyOrderedDictTypeObject)) [[unlikely]] {
-        throw py::value_error(absl::StrFormat(
-            "Expected an instance of collections.OrderedDict, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of collections.OrderedDict, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 
 inline void AssertExactDefaultDict(const py::handle& object) {
     if (!py::type::handle_of(object).is(PyDefaultDictTypeObject)) [[unlikely]] {
-        throw py::value_error(absl::StrFormat(
-            "Expected an instance of collections.defaultdict, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of collections.defaultdict, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 
@@ -310,17 +311,17 @@ inline void AssertExactStandardDict(const py::handle& object) {
           py::type::handle_of(object).is(PyOrderedDictTypeObject) ||
           py::type::handle_of(object).is(PyDefaultDictTypeObject))) [[unlikely]] {
         throw py::value_error(
-            absl::StrFormat("Expected an instance of "
-                            "dict, collections.OrderedDict, or collections.defaultdict, "
-                            "got %s.",
-                            py::repr(object)));
+            "Expected an instance of "
+            "dict, collections.OrderedDict, or collections.defaultdict, "
+            "got " +
+            static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 
 inline void AssertExactDeque(const py::handle& object) {
     if (!py::type::handle_of(object).is(PyDequeTypeObject)) [[unlikely]] {
-        throw py::value_error(absl::StrFormat("Expected an instance of collections.deque, got %s.",
-                                              py::repr(object)));
+        throw py::value_error("Expected an instance of collections.deque, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 
@@ -357,8 +358,8 @@ inline bool IsNamedTuple(const py::handle& object) {
 }
 inline void AssertExactNamedTuple(const py::handle& object) {
     if (!IsNamedTupleInstance(object)) [[unlikely]] {
-        throw py::value_error(absl::StrFormat(
-            "Expected an instance of collections.namedtuple, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of collections.namedtuple, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 inline py::tuple NamedTupleGetFields(const py::handle& object) {
@@ -366,14 +367,14 @@ inline py::tuple NamedTupleGetFields(const py::handle& object) {
     if (PyType_Check(object.ptr())) [[unlikely]] {
         type = object;
         if (!IsNamedTupleClass(type)) [[unlikely]] {
-            throw py::type_error(absl::StrFormat("Expected a collections.namedtuple type, got %s.",
-                                                 py::repr(object)));
+            throw py::type_error("Expected a collections.namedtuple type, got " +
+                                 static_cast<std::string>(py::repr(object)) + ".");
         }
     } else [[likely]] {
         type = py::type::handle_of(object);
         if (!IsNamedTupleClass(type)) [[unlikely]] {
-            throw py::type_error(absl::StrFormat(
-                "Expected an instance of collections.namedtuple type, got %s.", py::repr(object)));
+            throw py::type_error("Expected an instance of collections.namedtuple type, got " +
+                                 static_cast<std::string>(py::repr(object)) + ".");
         }
     }
     return py::getattr(type, "_fields");
@@ -414,8 +415,8 @@ inline bool IsStructSequence(const py::handle& object) {
 }
 inline void AssertExactStructSequence(const py::handle& object) {
     if (!IsStructSequenceInstance(object)) [[unlikely]] {
-        throw py::value_error(absl::StrFormat(
-            "Expected an instance of PyStructSequence type, got %s.", py::repr(object)));
+        throw py::value_error("Expected an instance of PyStructSequence type, got " +
+                              static_cast<std::string>(py::repr(object)) + ".");
     }
 }
 inline py::tuple StructSequenceGetFields(const py::handle& object) {
@@ -423,14 +424,14 @@ inline py::tuple StructSequenceGetFields(const py::handle& object) {
     if (PyType_Check(object.ptr())) [[unlikely]] {
         type = object;
         if (!IsStructSequenceClass(type)) [[unlikely]] {
-            throw py::type_error(
-                absl::StrFormat("Expected a PyStructSequence type, got %s.", py::repr(object)));
+            throw py::type_error("Expected a PyStructSequence type, got " +
+                                 static_cast<std::string>(py::repr(object)) + ".");
         }
     } else [[likely]] {
         type = py::type::handle_of(object);
         if (!IsStructSequenceClass(type)) [[unlikely]] {
-            throw py::type_error(absl::StrFormat(
-                "Expected an instance of PyStructSequence type, got %s.", py::repr(object)));
+            throw py::type_error("Expected an instance of PyStructSequence type, got " +
+                                 static_cast<std::string>(py::repr(object)) + ".");
         }
     }
 
@@ -458,10 +459,10 @@ inline void TotalOrderSort(py::list& list) {  // NOLINT[runtime/references]
                 // Sort with `(f'{o.__class__.__module__}.{o.__class__.__qualname__}', o)`
                 auto sort_key_fn = py::cpp_function([](const py::object& o) {
                     py::handle t = py::type::handle_of(o);
-                    py::str qualname{absl::StrFormat(
-                        "%s.%s",
-                        static_cast<std::string>(py::getattr(t, "__module__").cast<py::str>()),
-                        static_cast<std::string>(py::getattr(t, "__qualname__").cast<py::str>()))};
+                    py::str qualname{
+                        static_cast<std::string>(py::getattr(t, "__module__").cast<py::str>()) +
+                        "." +
+                        static_cast<std::string>(py::getattr(t, "__qualname__").cast<py::str>())};
                     return py::make_tuple(qualname, o);
                 });
                 list.attr("sort")(py::arg("key") = sort_key_fn);

--- a/include/utils.h
+++ b/include/utils.h
@@ -31,12 +31,26 @@ limitations under the License.
 #include <utility>
 #include <vector>
 
-constexpr bool NONE_IS_LEAF = true;
-constexpr bool NONE_IS_NODE = false;
-
 namespace py = pybind11;
 using size_t = py::size_t;
 using ssize_t = py::ssize_t;
+
+// boost::hash_combine
+template <class T>
+inline void HashCombine(size_t& seed, const T& v) {  // NOLINT[runtime/references]
+    std::hash<T> hasher;
+    // NOLINTNEXTLINE[cppcoreguidelines-avoid-magic-numbers]
+    seed ^= (hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+template <class T>
+inline void HashCombine(ssize_t& seed, const T& v) {  // NOLINT[runtime/references]
+    std::hash<T> hasher;
+    // NOLINTNEXTLINE[cppcoreguidelines-avoid-magic-numbers]
+    seed ^= (hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
+constexpr bool NONE_IS_LEAF = true;
+constexpr bool NONE_IS_NODE = false;
 
 #define PyCollectionsModule (ImportCollections())
 #define PyOrderedDictTypeObject (ImportOrderedDict())

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,6 @@ pybind11_add_module(_C MODULE THIN_LTO "${optree_csrc}")
 target_link_libraries(
     _C
     PUBLIC
-    absl::flat_hash_map
+    absl::hash
     absl::str_format
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,5 @@ target_link_libraries(
     _C
     PUBLIC
     absl::flat_hash_map
-    absl::flat_hash_set
     absl::str_format
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,5 @@ pybind11_add_module(_C MODULE THIN_LTO "${optree_csrc}")
 target_link_libraries(
     _C
     PUBLIC
-    absl::hash
     absl::str_format
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,9 +24,3 @@ set(
 )
 
 pybind11_add_module(_C MODULE THIN_LTO "${optree_csrc}")
-
-target_link_libraries(
-    _C
-    PUBLIC
-    absl::str_format
-)

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -212,7 +212,8 @@ void BuildModule(py::module& mod) {  // NOLINT[runtime/references]
     reinterpret_cast<PyTypeObject*>(PyTreeSpecTypeObject.ptr())->tp_flags |=
         Py_TPFLAGS_IMMUTABLETYPE;
 #endif
-    if (PyType_Ready(reinterpret_cast<PyTypeObject*>(PyTreeSpecTypeObject.ptr())) < 0) {
+    if (PyType_Ready(reinterpret_cast<PyTypeObject*>(PyTreeSpecTypeObject.ptr())) < 0)
+        [[unlikely]] {
         INTERNAL_ERROR("`PyType_Ready(&PyTreeSpec_Type)` failed.");
     }
 }

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -201,10 +201,7 @@ void BuildModule(py::module& mod) {  // NOLINT[runtime/references]
             "Test for this treespec is a suffix of another object.",
             py::is_operator(),
             py::arg("other"))
-        .def(
-            "__hash__",
-            [](const PyTreeSpec& t) { return absl::HashOf(t); },
-            "Return the hash of the treespec.")
+        .def("__hash__", &PyTreeSpec::HashValue, "Return the hash of the treespec.")
         .def("__len__", &PyTreeSpec::GetNumLeaves, "Number of leaves in the tree.")
         .def(py::pickle([](const PyTreeSpec& t) { return t.ToPicklable(); },
                         [](const py::object& o) { return PyTreeSpec::FromPicklable(o); }),

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -30,8 +30,8 @@ template <bool NoneIsLeaf>
             registration->kind = kind;
             registration->type = type;
             EXPECT(registry.m_registrations.emplace(type, std::move(registration)).second,
-                   absl::StrFormat("PyTree type %s is already registered in the global namespace.",
-                                   py::repr(type)));
+                   "PyTree type " + static_cast<std::string>(py::repr(type)) +
+                       " is already registered in the global namespace.");
         };
         if (!NoneIsLeaf) {
             add_builtin_type(Py_TYPE(Py_None), PyTreeKind::None);
@@ -68,61 +68,61 @@ template <bool NoneIsLeaf>
     registration->from_iterable = py::reinterpret_borrow<py::function>(from_iterable);
     if (registry_namespace.empty()) [[unlikely]] {
         if (!registry->m_registrations.emplace(cls, std::move(registration)).second) [[unlikely]] {
-            throw py::value_error(absl::StrFormat(
-                "PyTree type %s is already registered in the global namespace.", py::repr(cls)));
+            throw py::value_error("PyTree type " + static_cast<std::string>(py::repr(cls)) +
+                                  " is already registered in the global namespace.");
         }
         if (IsNamedTupleClass(cls)) [[unlikely]] {
-            PyErr_WarnEx(
-                PyExc_UserWarning,
-                absl::StrFormat("PyTree type %s is a subclass of `collections.namedtuple`, "
-                                "which is already registered in the global namespace. "
-                                "Override it with custom flatten/unflatten functions.",
-                                py::repr(cls))
-                    .c_str(),
-                /*stack_level=*/2);
+            PyErr_WarnEx(PyExc_UserWarning,
+                         ("PyTree type " + static_cast<std::string>(py::repr(cls)) +
+                          " is a subclass of `collections.namedtuple`, "
+                          "which is already registered in the global namespace. "
+                          "Override it with custom flatten/unflatten functions.")
+                             .c_str(),
+                         /*stack_level=*/2);
         }
         if (IsStructSequenceClass(cls)) [[unlikely]] {
             PyErr_WarnEx(PyExc_UserWarning,
-                         absl::StrFormat("PyTree type %s is a class of `PyStructSequence`, "
-                                         "which is already registered in the global namespace. "
-                                         "Override it with custom flatten/unflatten functions.",
-                                         py::repr(cls))
+                         ("PyTree type " + static_cast<std::string>(py::repr(cls)) +
+                          " is a class of `PyStructSequence`, "
+                          "which is already registered in the global namespace. "
+                          "Override it with custom flatten/unflatten functions.")
                              .c_str(),
                          /*stack_level=*/2);
         }
     } else [[likely]] {
         if (registry->m_registrations.find(cls) != registry->m_registrations.end()) [[unlikely]] {
-            throw py::value_error(absl::StrFormat(
-                "PyTree type %s is already registered in the global namespace.", py::repr(cls)));
+            throw py::value_error("PyTree type " + static_cast<std::string>(py::repr(cls)) +
+                                  " is already registered in the global namespace.");
         }
         if (!registry->m_named_registrations
                  .emplace(std::make_pair(registry_namespace, cls), std::move(registration))
                  .second) [[unlikely]] {
-            throw py::value_error(
-                absl::StrFormat("PyTree type %s is already registered in namespace %s.",
-                                py::repr(cls),
-                                py::repr(py::str(registry_namespace))));
+            std::stringstream ss;
+            ss << "PyTree type " << static_cast<std::string>(py::repr(cls))
+               << " is already registered in namespace "
+               << static_cast<std::string>(py::repr(py::str(registry_namespace))) << ".";
+            throw py::value_error(ss.str());
         }
         if (IsNamedTupleClass(cls)) [[unlikely]] {
+            std::stringstream ss;
+            ss << "PyTree type " << static_cast<std::string>(py::repr(cls))
+               << " is a subclass of `collections.namedtuple`, "
+                  "which is already registered in the global namespace. "
+                  "Override it with custom flatten/unflatten functions in namespace "
+               << static_cast<std::string>(py::repr(py::str(registry_namespace))) << ".";
             PyErr_WarnEx(PyExc_UserWarning,
-                         absl::StrFormat(
-                             "PyTree type %s is a subclass of `collections.namedtuple`, "
-                             "which is already registered in the global namespace. "
-                             "Override it with custom flatten/unflatten functions in namespace %s.",
-                             py::repr(cls),
-                             py::repr(py::str(registry_namespace)))
-                             .c_str(),
+                         ss.str().c_str(),
                          /*stack_level=*/2);
         }
         if (IsStructSequenceClass(cls)) [[unlikely]] {
+            std::stringstream ss;
+            ss << "PyTree type " << static_cast<std::string>(py::repr(cls))
+               << " is a class of `PyStructSequence`, "
+                  "which is already registered in the global namespace. "
+                  "Override it with custom flatten/unflatten functions in namespace "
+               << static_cast<std::string>(py::repr(py::str(registry_namespace))) << ".";
             PyErr_WarnEx(PyExc_UserWarning,
-                         absl::StrFormat(
-                             "PyTree type %s is a class of `PyStructSequence`, "
-                             "which is already registered in the global namespace. "
-                             "Override it with custom flatten/unflatten functions in namespace %s.",
-                             py::repr(cls),
-                             py::repr(py::str(registry_namespace)))
-                             .c_str(),
+                         ss.str().c_str(),
                          /*stack_level=*/2);
         }
     }

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -842,4 +842,12 @@ py::object PyTreeSpec::ToPicklable() const {
     return FromPicklableImpl(picklable);
 }
 
+size_t PyTreeSpec::ThreadIndentTypeHash::operator()(
+    const std::pair<const PyTreeSpec*, std::thread::id>& p) const {
+    size_t seed = 0;
+    HashCombine(seed, p.first);
+    HashCombine(seed, p.second);
+    return seed;
+}
+
 }  // namespace optree

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -172,7 +172,9 @@ std::unique_ptr<PyTreeSpec> PyTreeSpec::Compose(const PyTreeSpec& inner_treespec
     const ssize_t num_inner_nodes = inner_treespec.GetNumNodes();
     for (const Node& node : m_traversal) {
         if (node.kind == PyTreeKind::Leaf) [[likely]] {
-            absl::c_copy(inner_treespec.m_traversal, std::back_inserter(treespec->m_traversal));
+            std::copy(inner_treespec.m_traversal.begin(),
+                      inner_treespec.m_traversal.end(),
+                      std::back_inserter(treespec->m_traversal));
         } else [[unlikely]] {
             Node new_node{node};
             new_node.num_leaves = node.num_leaves * num_inner_leaves;
@@ -363,7 +365,9 @@ std::vector<std::unique_ptr<PyTreeSpec>> PyTreeSpec::Children() const {
     auto out = std::make_unique<PyTreeSpec>();
     ssize_t num_leaves = 0;
     for (const PyTreeSpec& treespec : treespecs) {
-        absl::c_copy(treespec.m_traversal, std::back_inserter(out->m_traversal));
+        std::copy(treespec.m_traversal.begin(),
+                  treespec.m_traversal.end(),
+                  std::back_inserter(out->m_traversal));
         num_leaves += treespec.GetNumLeaves();
     }
     Node node;

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -605,7 +605,7 @@ ssize_t PyTreeSpec::HashValueImpl() const {
 
 ssize_t PyTreeSpec::HashValue() const {
     std::pair<const PyTreeSpec*, std::thread::id> indent{this, std::this_thread::get_id()};
-    if (sm_hash_running.contains(indent)) {
+    if (sm_hash_running.contains(indent)) [[unlikely]] {
         return 0;
     }
 
@@ -800,10 +800,10 @@ std::string PyTreeSpec::ToStringImpl() const {
     EXPECT_EQ(agenda.size(), 1, "PyTreeSpec traversal did not yield a singleton.");
     std::stringstream ss;
     ss << "PyTreeSpec(" << agenda.back();
-    if (m_none_is_leaf) {
+    if (m_none_is_leaf) [[unlikely]] {
         ss << ", NoneIsLeaf";
     }
-    if (!m_namespace.empty()) {
+    if (!m_namespace.empty()) [[unlikely]] {
         ss << ", namespace=" << static_cast<std::string>(py::repr(py::str(m_namespace)));
     }
     ss << ")";
@@ -812,7 +812,7 @@ std::string PyTreeSpec::ToStringImpl() const {
 
 std::string PyTreeSpec::ToString() const {
     std::pair<const PyTreeSpec*, std::thread::id> indent{this, std::this_thread::get_id()};
-    if (sm_repr_running.contains(indent)) {
+    if (sm_repr_running.contains(indent)) [[unlikely]] {
         return "...";
     }
 

--- a/src/treespec/unflatten.cpp
+++ b/src/treespec/unflatten.cpp
@@ -56,11 +56,7 @@ py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
             case PyTreeKind::StructSequence:
             case PyTreeKind::Custom: {
                 const ssize_t size = py::ssize_t_cast(agenda.size());
-                absl::Span<py::object> span;
-                if (node.arity > 0) [[likely]] {
-                    span = absl::Span<py::object>(&agenda[size - node.arity], node.arity);
-                }
-                py::object out = MakeNode(node, span);
+                py::object out = MakeNode(node, &agenda[size - node.arity], node.arity);
                 agenda.resize(size - node.arity);
                 agenda.emplace_back(std::move(out));
                 break;

--- a/src/treespec/unflatten.cpp
+++ b/src/treespec/unflatten.cpp
@@ -33,10 +33,10 @@ py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
             case PyTreeKind::Leaf: {
                 if (node.kind == PyTreeKind::Leaf || m_none_is_leaf) [[likely]] {
                     if (it == leaves.end()) [[unlikely]] {
-                        throw py::value_error(absl::StrFormat(
-                            "Too few leaves for PyTreeSpec; expected: %ld, got: %ld.",
-                            GetNumLeaves(),
-                            leaf_count));
+                        std::stringstream ss;
+                        ss << "Too few leaves for PyTreeSpec; expected: " << GetNumLeaves()
+                           << ", got: " << leaf_count << ".";
+                        throw py::value_error(ss.str());
                     }
                     agenda.emplace_back(py::reinterpret_borrow<py::object>(*it));
                     ++it;
@@ -67,8 +67,9 @@ py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
         }
     }
     if (it != leaves.end()) [[unlikely]] {
-        throw py::value_error(
-            absl::StrFormat("Too many leaves for PyTreeSpec; expected: %ld.", GetNumLeaves()));
+        std::stringstream ss;
+        ss << "Too many leaves for PyTreeSpec; expected: " << GetNumLeaves() << ".";
+        throw py::value_error(ss.str());
     }
     EXPECT_EQ(agenda.size(), 1, "PyTreeSpec traversal did not yield a singleton.");
     return std::move(agenda.back());

--- a/src/treespec/unflatten.cpp
+++ b/src/treespec/unflatten.cpp
@@ -21,7 +21,7 @@ namespace optree {
 
 template <typename Span>
 py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
-    auto agenda = absl::InlinedVector<py::object, 4>{};
+    auto agenda = reserved_vector<py::object>(4);
     auto it = leaves.begin();
     ssize_t leaf_count = 0;
     for (const Node& node : m_traversal) {


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Resolves #84

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Implemented Tasks

- [X] `absl::Span` -> `(pointer, length)`
- [X] `absl::c_copy` -> `std::copy`
- [X] `absl::InlinedVector` -> `std::vector`
- [X] `absl::flat_hash_set` -> `std::unordered_set`
- [X] `absl::flat_hash_map` -> `std::unordered_map`
- [X] `AbslHashValue` -> custom hash function
- [X] `absl::HashOf` -> `std::hash` + custom hash combine function
- [X] `absl::StrAppendFormat` -> `std::stringstream`
- [X] `absl::StrCat` -> `std::stringstream`
- [X] `absl::StrFormat` -> `std::stringstream`
- [X] `absl::StrJoin` -> `std::stringstream`

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
