### PR TITLE
refactor(typing): use `__bases__` rather than `__base__` in function `is_structseq_class`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Use `__bases__` rather than `__base__` in function `is_structseq_class` by [@XuehaiPan](https://github.com/XuehaiPan) in [#104](https://github.com/metaopt/optree/pull/104).
 
 ### Fixed
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -75,3 +75,6 @@ jax
 numpy
 torch
 dtype
+getattr
+setattr
+delattr

--- a/include/utils.h
+++ b/include/utils.h
@@ -388,7 +388,10 @@ inline bool IsStructSequenceClassImpl(const py::handle& type) {
     // We can only identify PyStructSequences heuristically, here by the presence of
     // n_sequence_fields, n_fields, n_unnamed_fields attributes.
     auto* type_object = reinterpret_cast<PyTypeObject*>(type.ptr());
-    if (type_object->tp_base == &PyTuple_Type &&
+    if (type_object->tp_bases != nullptr &&
+        static_cast<bool>(PyTuple_CheckExact(type_object->tp_bases)) &&
+        PyTuple_GET_SIZE(type_object->tp_bases) == 1 &&
+        PyTuple_GET_ITEM(type_object->tp_bases, 0) == reinterpret_cast<PyObject*>(&PyTuple_Type) &&
         !static_cast<bool>(PyType_HasFeature(type_object, Py_TPFLAGS_BASETYPE))) [[unlikely]] {
         // NOLINTNEXTLINE[readability-use-anyofallof]
         for (const char* name : {"n_sequence_fields", "n_fields", "n_unnamed_fields"}) {

--- a/include/utils.h
+++ b/include/utils.h
@@ -386,7 +386,7 @@ inline py::tuple NamedTupleGetFields(const py::handle& object) {
 
 inline bool IsStructSequenceClassImpl(const py::handle& type) {
     // We can only identify PyStructSequences heuristically, here by the presence of
-    // n_sequence_fields, n_fields, n_unnamed_fields attributes.
+    // n_fields, n_sequence_fields, n_unnamed_fields attributes.
     auto* type_object = reinterpret_cast<PyTypeObject*>(type.ptr());
     if (type_object->tp_bases != nullptr &&
         static_cast<bool>(PyTuple_CheckExact(type_object->tp_bases)) &&
@@ -394,7 +394,7 @@ inline bool IsStructSequenceClassImpl(const py::handle& type) {
         PyTuple_GET_ITEM(type_object->tp_bases, 0) == reinterpret_cast<PyObject*>(&PyTuple_Type) &&
         !static_cast<bool>(PyType_HasFeature(type_object, Py_TPFLAGS_BASETYPE))) [[unlikely]] {
         // NOLINTNEXTLINE[readability-use-anyofallof]
-        for (const char* name : {"n_sequence_fields", "n_fields", "n_unnamed_fields"}) {
+        for (const char* name : {"n_fields", "n_sequence_fields", "n_unnamed_fields"}) {
             if (PyObject* attr = PyObject_GetAttrString(type.ptr(), name)) [[unlikely]] {
                 bool result = static_cast<bool>(PyLong_CheckExact(attr));
                 Py_DECREF(attr);

--- a/optree/typing.py
+++ b/optree/typing.py
@@ -96,7 +96,7 @@ KT = TypeVar('KT')
 VT = TypeVar('VT')
 
 
-Children = Sequence[T]
+Children = Iterable[T]
 _MetaData = TypeVar('_MetaData', bound=Hashable)
 MetaData = Optional[_MetaData]
 
@@ -369,7 +369,7 @@ def is_structseq_class(cls: type) -> bool:
     return (
         isinstance(cls, type)
         # Check direct inheritance from `tuple` rather than `issubclass(cls, tuple)`
-        and cls.__base__ is tuple
+        and cls.__bases__ == (tuple,)
         # Check PyStructSequence members
         and isinstance(getattr(cls, 'n_sequence_fields', None), int)
         and isinstance(getattr(cls, 'n_fields', None), int)

--- a/optree/typing.py
+++ b/optree/typing.py
@@ -21,7 +21,6 @@ import types
 from typing import (
     Any,
     Callable,
-    ClassVar,
     DefaultDict,
     Deque,
     Dict,
@@ -338,9 +337,9 @@ class _StructSequenceMeta(type):
 class structseq(tuple, Generic[_T_co], metaclass=_StructSequenceMeta):  # type: ignore[misc] # noqa: N801
     """A generic type stub for CPython's ``PyStructSequence`` type."""
 
-    n_fields: Final[ClassVar[int]]  # type: ignore[misc] # pylint: disable=invalid-name
-    n_sequence_fields: Final[ClassVar[int]]  # type: ignore[misc] # pylint: disable=invalid-name
-    n_unnamed_fields: Final[ClassVar[int]]  # type: ignore[misc] # pylint: disable=invalid-name
+    n_fields: Final[int]  # type: ignore[misc] # pylint: disable=invalid-name
+    n_sequence_fields: Final[int]  # type: ignore[misc] # pylint: disable=invalid-name
+    n_unnamed_fields: Final[int]  # type: ignore[misc] # pylint: disable=invalid-name
 
     def __init_subclass__(cls) -> NoReturn:
         """Prohibit subclassing."""
@@ -371,8 +370,8 @@ def is_structseq_class(cls: type) -> bool:
         # Check direct inheritance from `tuple` rather than `issubclass(cls, tuple)`
         and cls.__bases__ == (tuple,)
         # Check PyStructSequence members
-        and isinstance(getattr(cls, 'n_sequence_fields', None), int)
         and isinstance(getattr(cls, 'n_fields', None), int)
+        and isinstance(getattr(cls, 'n_sequence_fields', None), int)
         and isinstance(getattr(cls, 'n_unnamed_fields', None), int)
         # Check the type does not allow subclassing
         and not (cls.__flags__ & Py_TPFLAGS_BASETYPE)

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -253,7 +253,10 @@ void BuildModule(py::module& mod) {  // NOLINT[runtime/references]
         Py_TPFLAGS_IMMUTABLETYPE;
     reinterpret_cast<PyTypeObject*>(PyTreeKindTypeObject.ptr())->tp_flags |=
         Py_TPFLAGS_IMMUTABLETYPE;
+    reinterpret_cast<PyTypeObject*>(PyTreeSpecTypeObject.ptr())->tp_flags &= ~Py_TPFLAGS_READY;
+    reinterpret_cast<PyTypeObject*>(PyTreeKindTypeObject.ptr())->tp_flags &= ~Py_TPFLAGS_READY;
 #endif
+
     if (PyType_Ready(reinterpret_cast<PyTypeObject*>(PyTreeSpecTypeObject.ptr())) < 0)
         [[unlikely]] {
         INTERNAL_ERROR("`PyType_Ready(&PyTreeSpec_Type)` failed.");

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -30,8 +30,8 @@ class FakeNamedTuple(tuple):
 
 
 class FakeStructSequence(tuple):
-    n_sequence_fields = 9
     n_fields = 11
+    n_sequence_fields = 9
     n_unnamed_fields = 0
 
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

Use `cls.__bases__ == (tuple,)` rather than `cls.__base__ is tuple` to check the direct inheritance from `tuple`.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

See also https://github.com/pytorch/pytorch/pull/113258#discussion_r1386931064

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
