### PR TITLE
perf: intern cached `str` objects

### DIFF
--- a/optree/typing.py
+++ b/optree/typing.py
@@ -351,7 +351,7 @@ class structseq(tuple, Generic[_T_co], metaclass=_StructSequenceMeta):  # type: 
         raise TypeError("type 'structseq' is not an acceptable base type")
 
     # pylint: disable-next=unused-argument,redefined-builtin
-    def __new__(cls: type[Self], sequence: Iterable[_T_co], dict: dict[str, Any] = ...) -> Self:
+    def __new__(cls, sequence: Iterable[_T_co], dict: dict[str, Any] = ...) -> Self:
         raise NotImplementedError
 
 

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -128,12 +128,12 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
             .value("DEQUE", PyTreeKind::Deque, "A collections.deque.")
             .value("STRUCTSEQUENCE", PyTreeKind::StructSequence, "A PyStructSequence.");
     reinterpret_cast<PyTypeObject*>(PyTreeKindTypeObject.ptr())->tp_name = "optree.PyTreeKind";
-    py::setattr(PyTreeKindTypeObject.ptr(), "__module__", py::str("optree"));
+    py::setattr(PyTreeKindTypeObject.ptr(), Py_Get_ID(__module__), Py_Get_ID(optree));
 
     auto PyTreeSpecTypeObject =
         py::class_<PyTreeSpec>(mod, "PyTreeSpec", "Representing the structure of the pytree.");
     reinterpret_cast<PyTypeObject*>(PyTreeSpecTypeObject.ptr())->tp_name = "optree.PyTreeSpec";
-    py::setattr(PyTreeSpecTypeObject.ptr(), "__module__", py::str("optree"));
+    py::setattr(PyTreeSpecTypeObject.ptr(), Py_Get_ID(__module__), Py_Get_ID(optree));
 
     PyTreeSpecTypeObject
         .def_property_readonly(


### PR DESCRIPTION
## Description

Describe your changes in detail.

Intern cached string literals to speed up Python internal dictionary lookup.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
