### PR TITLE
refactor: reorder cases for `namedtuple` and `PyStructSequence` types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,11 +26,11 @@ repos:
       - id: debug-statements
       - id: double-quote-string-fixer
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v17.0.5
+    rev: v17.0.6
     hooks:
       - id: clang-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Cache intermediate `str` objects in `PyObject_GetAttr` calls by [@XuehaiPan](https://github.com/XuehaiPan) in [#106](https://github.com/metaopt/optree/pull/106).
+- Cache intermediate `str` objects in `PyObject_GetAttr` calls by [@XuehaiPan](https://github.com/XuehaiPan) in [#106](https://github.com/metaopt/optree/pull/106) and [#109](https://github.com/metaopt/optree/pull/109).
 - Install `clang-format` and `clang-tidy` from PyPI by [@XuehaiPan](https://github.com/XuehaiPan) in [#107](https://github.com/metaopt/optree/pull/107).
 - Also check `_make` and `_asdict` in function `is_namedtuple_class` by [@XuehaiPan](https://github.com/XuehaiPan) in [#105](https://github.com/metaopt/optree/pull/105).
 
 ### Changed
 
+- Reorder cases for `namedtuple` and `PyStructSequence` types by [@XuehaiPan](https://github.com/XuehaiPan) in [#111](https://github.com/metaopt/optree/pull/111).
 - Use `__bases__` rather than `__base__` in function `is_structseq_class` by [@XuehaiPan](https://github.com/XuehaiPan) in [#104](https://github.com/metaopt/optree/pull/104).
 
 ### Fixed

--- a/include/utils.h
+++ b/include/utils.h
@@ -433,11 +433,13 @@ inline bool IsStructSequenceClassImpl(const py::handle& type) {
     // We can only identify PyStructSequences heuristically, here by the presence of
     // n_fields, n_sequence_fields, n_unnamed_fields attributes.
     auto* type_object = reinterpret_cast<PyTypeObject*>(type.ptr());
-    if (type_object->tp_bases != nullptr &&
+    if (PyType_FastSubclass(type_object, Py_TPFLAGS_TUPLE_SUBCLASS) &&
+        !static_cast<bool>(PyType_HasFeature(type_object, Py_TPFLAGS_BASETYPE)) &&
+        type_object->tp_bases != nullptr &&
         static_cast<bool>(PyTuple_CheckExact(type_object->tp_bases)) &&
         PyTuple_GET_SIZE(type_object->tp_bases) == 1 &&
-        PyTuple_GET_ITEM(type_object->tp_bases, 0) == reinterpret_cast<PyObject*>(&PyTuple_Type) &&
-        !static_cast<bool>(PyType_HasFeature(type_object, Py_TPFLAGS_BASETYPE))) [[unlikely]] {
+        PyTuple_GET_ITEM(type_object->tp_bases, 0) == reinterpret_cast<PyObject*>(&PyTuple_Type))
+        [[unlikely]] {
         // NOLINTNEXTLINE[readability-use-anyofallof]
         for (PyObject* name :
              {Py_Get_ID(n_fields), Py_Get_ID(n_sequence_fields), Py_Get_ID(n_unnamed_fields)}) {

--- a/optree/ops.py
+++ b/optree/ops.py
@@ -2215,13 +2215,13 @@ def _child_keys(
     if handler:
         return list(handler(tree))
 
-    if is_namedtuple(tree):
-        # Handle namedtuple as a special case, based on heuristic
-        return list(map(AttributeKeyPathEntry, namedtuple_fields(tree)))  # type: ignore[arg-type]
-
     if is_structseq(tree):
         # Handle PyStructSequence as a special case, based on heuristic
         return list(map(AttributeKeyPathEntry, structseq_fields(tree)))  # type: ignore[arg-type]
+
+    if is_namedtuple(tree):
+        # Handle namedtuple as a special case, based on heuristic
+        return list(map(AttributeKeyPathEntry, namedtuple_fields(tree)))  # type: ignore[arg-type]
 
     num_children = treespec.num_children
     return list(map(FlattenedKeyPathEntry, range(num_children)))

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -415,10 +415,10 @@ def _pytree_node_registry_get(
     handler = _NODETYPE_REGISTRY.get((namespace, cls))
     if handler is not None:
         return handler
-    if is_namedtuple_class(cls):
-        return _NODETYPE_REGISTRY.get(namedtuple)  # type: ignore[call-overload] # noqa: PYI024
     if is_structseq_class(cls):
         return _NODETYPE_REGISTRY.get(structseq)
+    if is_namedtuple_class(cls):
+        return _NODETYPE_REGISTRY.get(namedtuple)  # type: ignore[call-overload] # noqa: PYI024
     return None
 
 

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -82,19 +82,18 @@ template <bool NoneIsLeaf>
             throw py::value_error("PyTree type " + static_cast<std::string>(py::repr(cls)) +
                                   " is already registered in the global namespace.");
         }
-        if (IsNamedTupleClass(cls)) [[unlikely]] {
-            PyErr_WarnEx(PyExc_UserWarning,
-                         ("PyTree type " + static_cast<std::string>(py::repr(cls)) +
-                          " is a subclass of `collections.namedtuple`, "
-                          "which is already registered in the global namespace. "
-                          "Override it with custom flatten/unflatten functions.")
-                             .c_str(),
-                         /*stack_level=*/2);
-        }
         if (IsStructSequenceClass(cls)) [[unlikely]] {
             PyErr_WarnEx(PyExc_UserWarning,
                          ("PyTree type " + static_cast<std::string>(py::repr(cls)) +
                           " is a class of `PyStructSequence`, "
+                          "which is already registered in the global namespace. "
+                          "Override it with custom flatten/unflatten functions.")
+                             .c_str(),
+                         /*stack_level=*/2);
+        } else if (IsNamedTupleClass(cls)) [[unlikely]] {
+            PyErr_WarnEx(PyExc_UserWarning,
+                         ("PyTree type " + static_cast<std::string>(py::repr(cls)) +
+                          " is a subclass of `collections.namedtuple`, "
                           "which is already registered in the global namespace. "
                           "Override it with custom flatten/unflatten functions.")
                              .c_str(),
@@ -114,21 +113,20 @@ template <bool NoneIsLeaf>
                 << static_cast<std::string>(py::repr(py::str(registry_namespace))) << ".";
             throw py::value_error(oss.str());
         }
-        if (IsNamedTupleClass(cls)) [[unlikely]] {
+        if (IsStructSequenceClass(cls)) [[unlikely]] {
             std::ostringstream oss{};
             oss << "PyTree type " << static_cast<std::string>(py::repr(cls))
-                << " is a subclass of `collections.namedtuple`, "
+                << " is a class of `PyStructSequence`, "
                    "which is already registered in the global namespace. "
                    "Override it with custom flatten/unflatten functions in namespace "
                 << static_cast<std::string>(py::repr(py::str(registry_namespace))) << ".";
             PyErr_WarnEx(PyExc_UserWarning,
                          oss.str().c_str(),
                          /*stack_level=*/2);
-        }
-        if (IsStructSequenceClass(cls)) [[unlikely]] {
+        } else if (IsNamedTupleClass(cls)) [[unlikely]] {
             std::ostringstream oss{};
             oss << "PyTree type " << static_cast<std::string>(py::repr(cls))
-                << " is a class of `PyStructSequence`, "
+                << " is a subclass of `collections.namedtuple`, "
                    "which is already registered in the global namespace. "
                    "Override it with custom flatten/unflatten functions in namespace "
                 << static_cast<std::string>(py::repr(py::str(registry_namespace))) << ".";

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -1001,11 +1001,11 @@ template <bool NoneIsLeaf>
         return registration->kind;
     }
     *custom = nullptr;
-    if (IsNamedTupleInstance(handle)) [[unlikely]] {
-        return PyTreeKind::NamedTuple;
-    }
     if (IsStructSequenceInstance(handle)) [[unlikely]] {
         return PyTreeKind::StructSequence;
+    }
+    if (IsNamedTupleInstance(handle)) [[unlikely]] {
+        return PyTreeKind::NamedTuple;
     }
     return PyTreeKind::Leaf;
 }

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1574,16 +1574,16 @@ def test_tree_flatten_one_level(tree, none_is_leaf, namespace):  # noqa: C901
             elif node_type is deque:
                 assert metadata == node.maxlen
                 assert one_level_treespec.kind == optree.PyTreeKind.DEQUE
-            elif optree.is_namedtuple(node):
-                assert optree.is_namedtuple_class(node_type)
-                assert metadata is node_type
-                assert one_level_treespec.kind == optree.PyTreeKind.NAMEDTUPLE
             elif optree.is_structseq(node):
                 assert optree.is_structseq_class(node_type)
                 assert isinstance(node, optree.typing.structseq)
                 assert issubclass(node_type, optree.typing.structseq)
                 assert metadata is node_type
                 assert one_level_treespec.kind == optree.PyTreeKind.STRUCTSEQUENCE
+            elif optree.is_namedtuple(node):
+                assert optree.is_namedtuple_class(node_type)
+                assert metadata is node_type
+                assert one_level_treespec.kind == optree.PyTreeKind.NAMEDTUPLE
             else:
                 assert one_level_treespec.kind == optree.PyTreeKind.CUSTOM
             assert len(entries) == len(children)


### PR DESCRIPTION
## Description

Describe your changes in detail.

Move the `PyStructSequence` check before the `namedtuple` check.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

The `PyStructSequence` types will be more similar to the `namedtuple` types in the future. It's hard to distinguish these two types if the `PyStructSequence` types will have `_fields` attributes.

- pytorch/pytorch#113258
- python/cpython#46145
- python/cpython#108648

This PR moves the `PyStructSequence` type check before the `namedtuple` type check.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
