### PR TITLE
refactor: standardize `py::handle` and `py::object` usage in function signature

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: clang-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.1.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -39,7 +39,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 23.12.0
+    rev: 23.12.1
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Standardize `py::handle` and `py::object` usage in function signature by [@XuehaiPan](https://github.com/XuehaiPan) in [#115](https://github.com/metaopt/optree/pull/115).
 - Reorder cases for `namedtuple` and `PyStructSequence` types by [@XuehaiPan](https://github.com/XuehaiPan) in [#111](https://github.com/metaopt/optree/pull/111).
 - Use `__bases__` rather than `__base__` in function `is_structseq_class` by [@XuehaiPan](https://github.com/XuehaiPan) in [#104](https://github.com/metaopt/optree/pull/104).
 

--- a/include/registry.h
+++ b/include/registry.h
@@ -80,15 +80,9 @@ class PyTreeTypeRegistry {
 
     // Finds the custom type registration for `type`. Returns nullptr if none exists.
     template <bool NoneIsLeaf>
-    static const Registration *Lookup(const py::handle &type,
-                                      const std::string &registry_namespace);
+    static const Registration *Lookup(const py::object &cls, const std::string &registry_namespace);
 
  private:
-    template <bool NoneIsLeaf>
-    struct SingletonHelper {
-        static PyTreeTypeRegistry *get();
-    };
-
     template <bool NoneIsLeaf>
     static PyTreeTypeRegistry *Singleton();
 
@@ -132,12 +126,13 @@ class PyTreeTypeRegistry {
                         const std::pair<std::string, py::handle> &b) const;
     };
 
-    std::unordered_map<py::object, std::unique_ptr<Registration>, TypeHash, TypeEq> m_registrations;
+    std::unordered_map<py::object, std::unique_ptr<Registration>, TypeHash, TypeEq>
+        m_registrations{};
     std::unordered_map<std::pair<std::string, py::object>,
                        std::unique_ptr<Registration>,
                        NamedTypeHash,
                        NamedTypeEq>
-        m_named_registrations;
+        m_named_registrations{};
 };
 
 }  // namespace optree

--- a/include/utils.h
+++ b/include/utils.h
@@ -547,7 +547,7 @@ inline py::list SortedDictKeys(const py::dict& dict) {
     return keys;
 }
 
-inline bool DictKeysEqual(const py::list& /* unique */ keys, const py::dict& dict) {
+inline bool DictKeysEqual(const py::list& /*unique*/ keys, const py::dict& dict) {
     ssize_t list_len = GET_SIZE<py::list>(keys);
     ssize_t dict_len = GET_SIZE<py::dict>(dict);
     if (list_len != dict_len) [[likely]] {  // assumes keys are unique
@@ -566,7 +566,7 @@ inline bool DictKeysEqual(const py::list& /* unique */ keys, const py::dict& dic
     return true;
 }
 
-inline std::pair<py::list, py::list> DictKeysDifference(const py::list& /* unique */ keys,
+inline std::pair<py::list, py::list> DictKeysDifference(const py::list& /*unique*/ keys,
                                                         const py::dict& dict) {
     py::set expected_keys{keys};
     py::set got_keys{DictKeys(dict)};

--- a/src/treespec/traversal.cpp
+++ b/src/treespec/traversal.cpp
@@ -25,7 +25,7 @@ limitations under the License.
 namespace optree {
 
 py::object PyTreeSpec::Walk(const py::function& f_node,
-                            const py::handle& f_leaf,
+                            const py::object& f_leaf,
                             const py::iterable& leaves) const {
     auto agenda = reserved_vector<py::object>(4);
     auto it = leaves.begin();

--- a/src/treespec/unflatten.cpp
+++ b/src/treespec/unflatten.cpp
@@ -29,7 +29,7 @@ template <typename Span>
 py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
     auto agenda = reserved_vector<py::object>(4);
     auto it = leaves.begin();
-    ssize_t leaf_count = 0;
+    ssize_t num_leaves = 0;
     for (const Node& node : m_traversal) {
         EXPECT_GE(
             py::ssize_t_cast(agenda.size()), node.arity, "Too few elements for PyTreeSpec node.");
@@ -39,12 +39,12 @@ py::object PyTreeSpec::UnflattenImpl(const Span& leaves) const {
                 if (it == leaves.end()) [[unlikely]] {
                     std::ostringstream oss{};
                     oss << "Too few leaves for PyTreeSpec; expected: " << GetNumLeaves()
-                        << ", got: " << leaf_count << ".";
+                        << ", got: " << num_leaves << ".";
                     throw py::value_error(oss.str());
                 }
                 agenda.emplace_back(py::reinterpret_borrow<py::object>(*it));
                 ++it;
-                ++leaf_count;
+                ++num_leaves;
                 break;
             }
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

- Use `py::object` in public methods.
- Use `py::handle` in implementation details.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
