### PR TITLE
fix(treespec): fix potential segmentation fault when modifying `treespec.entries()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix potential segmentation fault when modifying `treespec.entries()` by [@XuehaiPan](https://github.com/XuehaiPan) in [#116](https://github.com/metaopt/optree/pull/116).
 
 ### Removed
 

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -205,7 +205,7 @@ class PyTreeSpec {
         ssize_t num_nodes = 0;
 
         // For a Dict or DefaultDict, contains the keys in insertion order.
-        py::object ordered_keys{};
+        py::object original_keys{};
     };
 
     // Nodes, in a post-order traversal. We use an ordered traversal to minimize allocations, and

--- a/src/treespec/flatten.cpp
+++ b/src/treespec/flatten.cpp
@@ -95,7 +95,7 @@ bool PyTreeSpec::FlattenIntoImpl(const py::handle& handle,
                 auto dict = py::reinterpret_borrow<py::dict>(handle);
                 py::list keys = DictKeys(dict);
                 if (node.kind != PyTreeKind::OrderedDict) [[likely]] {
-                    node.ordered_keys = py::getattr(keys, Py_Get_ID(copy))();
+                    node.original_keys = py::getattr(keys, Py_Get_ID(copy))();
                     TotalOrderSort(keys);
                 }
                 for (const py::handle& key : keys) {
@@ -289,7 +289,7 @@ bool PyTreeSpec::FlattenIntoWithPathImpl(const py::handle& handle,
                 auto dict = py::reinterpret_borrow<py::dict>(handle);
                 py::list keys = DictKeys(dict);
                 if (node.kind != PyTreeKind::OrderedDict) [[likely]] {
-                    node.ordered_keys = py::getattr(keys, Py_Get_ID(copy))();
+                    node.original_keys = py::getattr(keys, Py_Get_ID(copy))();
                     TotalOrderSort(keys);
                 }
                 for (const py::handle& key : keys) {

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -691,10 +691,10 @@ py::list PyTreeSpec::Entries() const {
 
         case PyTreeKind::Dict:
         case PyTreeKind::OrderedDict: {
-            return py::list{root.node_data};
+            return py::getattr(root.node_data, Py_Get_ID(copy))();
         }
         case PyTreeKind::DefaultDict: {
-            return py::list{GET_ITEM_BORROW<py::tuple>(root.node_data, 1)};
+            return py::getattr(GET_ITEM_BORROW<py::tuple>(root.node_data, 1), Py_Get_ID(copy))();
         }
 
         default:

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -312,7 +312,7 @@ bool PyTreeSpec::IsPrefix(const PyTreeSpec& other, const bool& strict) const {
     node.num_nodes = 1;
     node.node_data = root.node_data;
     node.custom = root.custom;
-    node.ordered_keys = root.ordered_keys;
+    node.original_keys = root.original_keys;
     switch (root.kind) {
         case PyTreeKind::Tuple:
         case PyTreeKind::List:
@@ -931,9 +931,9 @@ std::unique_ptr<PyTreeSpec> PyTreeSpec::Child(ssize_t index) const {
         case PyTreeKind::Dict: {
             py::dict dict{};
             auto keys = py::reinterpret_borrow<py::list>(node.node_data);
-            if (node.ordered_keys) [[unlikely]] {
+            if (node.original_keys) [[unlikely]] {
                 for (ssize_t i = 0; i < node.arity; ++i) {
-                    dict[GET_ITEM_HANDLE<py::list>(node.ordered_keys, i)] = py::none();
+                    dict[GET_ITEM_HANDLE<py::list>(node.original_keys, i)] = py::none();
                 }
             }
             for (ssize_t i = 0; i < node.arity; ++i) {
@@ -960,9 +960,9 @@ std::unique_ptr<PyTreeSpec> PyTreeSpec::Child(ssize_t index) const {
             py::dict dict{};
             py::object default_factory = GET_ITEM_BORROW<py::tuple>(node.node_data, 0);
             py::list keys = GET_ITEM_BORROW<py::tuple>(node.node_data, 1);
-            if (node.ordered_keys) [[unlikely]] {
+            if (node.original_keys) [[unlikely]] {
                 for (ssize_t i = 0; i < node.arity; ++i) {
-                    dict[GET_ITEM_HANDLE<py::list>(node.ordered_keys, i)] = py::none();
+                    dict[GET_ITEM_HANDLE<py::list>(node.original_keys, i)] = py::none();
                 }
             }
             for (ssize_t i = 0; i < node.arity; ++i) {
@@ -1320,7 +1320,7 @@ py::object PyTreeSpec::ToPicklable() const {
                                            node.custom != nullptr ? node.custom->type : py::none(),
                                            node.num_leaves,
                                            node.num_nodes,
-                                           node.ordered_keys ? node.ordered_keys : py::none()));
+                                           node.original_keys ? node.original_keys : py::none()));
     }
     return py::make_tuple(std::move(node_states), py::bool_(m_none_is_leaf), py::str(m_namespace));
 }
@@ -1352,7 +1352,7 @@ py::object PyTreeSpec::ToPicklable() const {
                 } else [[unlikely]] {
                     if (node.kind == PyTreeKind::Dict || node.kind == PyTreeKind::DefaultDict)
                         [[likely]] {
-                        node.ordered_keys = t[7].cast<py::list>();
+                        node.original_keys = t[7].cast<py::list>();
                     } else [[unlikely]] {
                         throw std::runtime_error("Malformed pickled PyTreeSpec.");
                     }

--- a/tests/test_treespec.py
+++ b/tests/test_treespec.py
@@ -415,6 +415,10 @@ def test_treespec_entries(tree, none_is_leaf, namespace):
         children = optree.treespec_children(spec)
         assert len(entries) == spec.num_children
         assert len(children) == spec.num_children
+        assert entries is not optree.treespec_entries(spec)
+        assert children is not optree.treespec_children(spec)
+        optree.treespec_entries(spec).clear()
+        optree.treespec_children(spec).clear()
         if spec.is_leaf():
             yield prefix
         for entry, child in zip(entries, children):


### PR DESCRIPTION
## Description

Describe your changes in detail.

Always make a copy of the dict key list. This fixes a potential segmentation fault when users modify `treespec.entries()`.

```python
In [1]: import optree

In [2]: spec = optree.tree_structure({'a': 1, 'b': 2})

In [3]: spec
Out[3]: PyTreeSpec({'a': *, 'b': *})

In [4]: spec.entries().clear()

In [5]: optree.tree_unflatten(spec, range(spec.num_leaves))
[1]    39564 segmentation fault  ipython
```

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
