### PR TITLE
feat(registry): add API to unregister node type in the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add API to unregister node type in the registry by [@XuehaiPan](https://github.com/XuehaiPan) in [#124](https://github.com/metaopt/optree/pull/124).
 - Add tree map functions with transposed outputs `tree_transpose_map` and `tree_transpose_map_with_path` by [@XuehaiPan](https://github.com/XuehaiPan) in [#127](https://github.com/metaopt/optree/pull/127).
 - Add static constructors to create `PyTreeSpec` instances by [@XuehaiPan](https://github.com/XuehaiPan) in [#120](https://github.com/metaopt/optree/pull/120).
 - Cache intermediate `str` objects in `PyObject_GetAttr` calls by [@XuehaiPan](https://github.com/XuehaiPan) in [#106](https://github.com/metaopt/optree/pull/106) and [#109](https://github.com/metaopt/optree/pull/109).
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow types to be registered in both the global namespace and custom namespaces by [@XuehaiPan](https://github.com/XuehaiPan) in [#124](https://github.com/metaopt/optree/pull/124).
 - Set `treespec_is_leaf` as strict by default by [@XuehaiPan](https://github.com/XuehaiPan) in [#120](https://github.com/metaopt/optree/pull/120).
 - Reorder functions for better code correspondence between C++ and Python by [@XuehaiPan](https://github.com/XuehaiPan) in [#117](https://github.com/metaopt/optree/pull/117).
 - Standardize `py::handle` and `py::object` usage in function signature by [@XuehaiPan](https://github.com/XuehaiPan) in [#115](https://github.com/metaopt/optree/pull/115).

--- a/docs/source/registry.rst
+++ b/docs/source/registry.rst
@@ -7,6 +7,7 @@ PyTree Node Registry
 
     register_pytree_node
     register_pytree_node_class
+    unregister_pytree_node
     Partial
     register_keypaths
     AttributeKeyPathEntry
@@ -14,6 +15,7 @@ PyTree Node Registry
 
 .. autofunction:: register_pytree_node
 .. autofunction:: register_pytree_node_class
+.. autofunction:: unregister_pytree_node
 .. autofunction:: Partial
 .. autofunction:: register_keypaths
 .. autofunction:: AttributeKeyPathEntry

--- a/include/treespec.h
+++ b/include/treespec.h
@@ -177,6 +177,8 @@ class PyTreeSpec {
                           const std::string &registry_namespace = "");
 
  private:
+    using RegistrationPtr = PyTreeTypeRegistry::RegistrationPtr;
+
     struct Node {
         PyTreeKind kind = PyTreeKind::Leaf;
 
@@ -200,7 +202,7 @@ class PyTreeSpec {
         py::object node_entries{};
 
         // Custom type registration. Must be null for non-custom types.
-        const PyTreeTypeRegistry::Registration *custom = nullptr;
+        RegistrationPtr custom{nullptr};
 
         // Number of leaf nodes in the subtree rooted at this node.
         ssize_t num_leaves = 0;
@@ -233,7 +235,7 @@ class PyTreeSpec {
     // Compute the node kind of a given Python object.
     template <bool NoneIsLeaf>
     static PyTreeKind GetKind(const py::handle &handle,
-                              PyTreeTypeRegistry::Registration const **custom,
+                              RegistrationPtr &custom,  // NOLINT[runtime/references]
                               const std::string &registry_namespace);
 
     // Recursive helper used to implement Flatten().

--- a/optree/_C.pyi
+++ b/optree/_C.pyi
@@ -127,5 +127,9 @@ def register_node(
     cls: type[CustomTreeNode[T]],
     flatten_func: FlattenFunc,
     unflatten_func: UnflattenFunc,
-    namespace: str,
+    namespace: str = '',
+) -> None: ...
+def unregister_node(
+    cls: type[CustomTreeNode[T]],
+    namespace: str = '',
 ) -> None: ...

--- a/optree/__init__.py
+++ b/optree/__init__.py
@@ -77,6 +77,7 @@ from optree.registry import (
     register_keypaths,
     register_pytree_node,
     register_pytree_node_class,
+    unregister_pytree_node,
 )
 from optree.typing import (
     CustomTreeNode,
@@ -155,6 +156,7 @@ __all__ = [
     # Registry
     'register_pytree_node',
     'register_pytree_node_class',
+    'unregister_pytree_node',
     'Partial',
     'register_keypaths',
     'AttributeKeyPathEntry',

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -332,6 +332,7 @@ def unregister_pytree_node(
         The removed registry entry.
 
     Raises:
+        TypeError: If the input type is not a class.
         TypeError: If the namespace is not a string.
         ValueError: If the namespace is an empty string.
         ValueError: If the type is a built-in type that cannot be unregistered.
@@ -350,6 +351,8 @@ def unregister_pytree_node(
         >>> # Unregister the Python type
         >>> unregister_pytree_node(set, namespace='set')
     """
+    if not inspect.isclass(cls):
+        raise TypeError(f'Expected a class, got {cls}.')
     if namespace is not __GLOBAL_NAMESPACE and not isinstance(namespace, str):
         raise TypeError(f'The namespace must be a string, got {namespace}.')
     if namespace == '':

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -346,12 +346,12 @@ def unregister_pytree_node(
         ...     set,
         ...     lambda s: (sorted(s), None, None),
         ...     lambda _, children: set(children),
-        ...     namespace='set',
+        ...     namespace='temp',
         ... )
         <class 'set'>
 
         >>> # Unregister the Python type
-        >>> unregister_pytree_node(set, namespace='set')
+        >>> unregister_pytree_node(set, namespace='temp')
     """
     if not inspect.isclass(cls):
         raise TypeError(f'Expected a class, got {cls}.')

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -290,10 +290,6 @@ def register_pytree_node_class(
 
         @register_pytree_node_class('mylist')
         class MyList(UserList):
-            def __init__(self, x, y):
-                self.x = x
-                self.y = y
-
             def tree_flatten(self):
                 return self.data, None, None
 

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -56,7 +56,7 @@ __all__ = [
 ]
 
 
-@dataclasses.dataclass(init=True, repr=True, eq=True, frozen=True, slots=True)
+@dataclasses.dataclass(init=True, repr=True, eq=True, frozen=True)
 class PyTreeNodeRegistryEntry:
     type: builtins.type
     flatten_func: FlattenFunc

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import inspect
 from collections import OrderedDict, defaultdict, deque, namedtuple
@@ -55,7 +56,8 @@ __all__ = [
 ]
 
 
-class PyTreeNodeRegistryEntry(NamedTuple):
+@dataclasses.dataclass(init=True, repr=True, eq=True, frozen=True, slots=True)
+class PyTreeNodeRegistryEntry:
     type: builtins.type
     flatten_func: FlattenFunc
     unflatten_func: UnflattenFunc

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -21,7 +21,7 @@ import inspect
 from collections import OrderedDict, defaultdict, deque, namedtuple
 from operator import methodcaller
 from threading import Lock
-from typing import Any, Callable, Iterable, NamedTuple, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, NamedTuple, Sequence, overload
 from typing_extensions import Self  # Python 3.11+
 
 from optree import _C
@@ -40,9 +40,14 @@ from optree.typing import (
 from optree.utils import safe_zip, total_order_sorted, unzip2
 
 
+if TYPE_CHECKING:
+    import builtins
+
+
 __all__ = [
     'register_pytree_node',
     'register_pytree_node_class',
+    'unregister_pytree_node',
     'Partial',
     'register_keypaths',
     'AttributeKeyPathEntry',
@@ -51,8 +56,10 @@ __all__ = [
 
 
 class PyTreeNodeRegistryEntry(NamedTuple):
+    type: builtins.type
     flatten_func: FlattenFunc
     unflatten_func: UnflattenFunc
+    namespace: str = ''
 
 
 # pylint: disable-next=missing-class-docstring,too-few-public-methods
@@ -101,6 +108,12 @@ def register_pytree_node(
 
     Returns:
         The same type as the input ``cls``.
+
+    Raises:
+        TypeError: If the input type is not a class.
+        TypeError: If the namespace is not a string.
+        ValueError: If the namespace is an empty string.
+        ValueError: If the type is already registered in the registry.
 
     Examples:
         >>> # Registry a Python type with lambda functions
@@ -194,8 +207,12 @@ def register_pytree_node(
 
     with __REGISTRY_LOCK:
         _C.register_node(cls, flatten_func, unflatten_func, namespace)
-        CustomTreeNode.register(cls)  # pylint: disable=no-member
-        _NODETYPE_REGISTRY[registration_key] = PyTreeNodeRegistryEntry(flatten_func, unflatten_func)
+        _NODETYPE_REGISTRY[registration_key] = PyTreeNodeRegistryEntry(
+            cls,
+            flatten_func,
+            unflatten_func,
+            namespace=namespace,
+        )
     return cls
 
 
@@ -243,6 +260,11 @@ def register_pytree_node_class(
     Returns:
         The same type as the input ``cls`` if the argument presents. Otherwise, return a decorator
         function that registers the class as a pytree node.
+
+    Raises:
+        TypeError: If the namespace is not a string.
+        ValueError: If the namespace is an empty string.
+        ValueError: If the type is already registered in the registry.
 
     This function is a thin wrapper around :func:`register_pytree_node`, and provides a
     class-oriented interface::
@@ -293,6 +315,56 @@ def register_pytree_node_class(
         raise TypeError(f'Expected a class, got {cls}.')
     register_pytree_node(cls, methodcaller('tree_flatten'), cls.tree_unflatten, namespace)
     return cls
+
+
+def unregister_pytree_node(
+    cls: type[CustomTreeNode[T]],
+    *,
+    namespace: str,
+) -> PyTreeNodeRegistryEntry:
+    """Remove a type from the pytree node registry.
+
+    Args:
+        cls (type): A Python type to remove from the pytree node registry.
+        namespace (str): The namespace of the pytree node registry to remove the type from.
+
+    Returns:
+        The removed registry entry.
+
+    Raises:
+        TypeError: If the namespace is not a string.
+        ValueError: If the namespace is an empty string.
+        ValueError: If the type is a built-in type that cannot be unregistered.
+        ValueError: If the type is not found in the registry.
+
+    Examples:
+        >>> # Register a Python type with lambda functions
+        >>> register_pytree_node(
+        ...     set,
+        ...     lambda s: (sorted(s), None, None),
+        ...     lambda _, children: set(children),
+        ...     namespace='set',
+        ... )
+        <class 'set'>
+
+        >>> # Unregister the Python type
+        >>> unregister_pytree_node(set, namespace='set')
+    """
+    if namespace is not __GLOBAL_NAMESPACE and not isinstance(namespace, str):
+        raise TypeError(f'The namespace must be a string, got {namespace}.')
+    if namespace == '':
+        raise ValueError('The namespace cannot be an empty string.')
+
+    registration_key: type | tuple[str, type]
+    if namespace is __GLOBAL_NAMESPACE:
+        registration_key = cls
+        namespace = ''
+    else:
+        registration_key = (namespace, cls)
+
+    with __REGISTRY_LOCK:
+        _C.unregister_node(cls, namespace)
+        return _NODETYPE_REGISTRY.pop(registration_key)
 
 
 def _sorted_items(items: Iterable[tuple[KT, VT]]) -> list[tuple[KT, VT]]:
@@ -391,15 +463,15 @@ def _structseq_unflatten(cls: type[structseq[T]], children: Iterable[T]) -> stru
 
 # pylint: disable=all
 _NODETYPE_REGISTRY: dict[type | tuple[str, type], PyTreeNodeRegistryEntry] = {  # fmt: off
-    type(None): PyTreeNodeRegistryEntry(_none_flatten, _none_unflatten),  # type: ignore[arg-type]
-    tuple: PyTreeNodeRegistryEntry(_tuple_flatten, _tuple_unflatten),  # type: ignore[arg-type]
-    list: PyTreeNodeRegistryEntry(_list_flatten, _list_unflatten),  # type: ignore[arg-type]
-    dict: PyTreeNodeRegistryEntry(_dict_flatten, _dict_unflatten),  # type: ignore[arg-type]
-    namedtuple: PyTreeNodeRegistryEntry(_namedtuple_flatten, _namedtuple_unflatten),  # type: ignore[arg-type,dict-item] # noqa: PYI024
-    OrderedDict: PyTreeNodeRegistryEntry(_ordereddict_flatten, _ordereddict_unflatten),  # type: ignore[arg-type]
-    defaultdict: PyTreeNodeRegistryEntry(_defaultdict_flatten, _defaultdict_unflatten),  # type: ignore[arg-type]
-    deque: PyTreeNodeRegistryEntry(_deque_flatten, _deque_unflatten),  # type: ignore[arg-type]
-    structseq: PyTreeNodeRegistryEntry(_structseq_flatten, _structseq_unflatten),  # type: ignore[arg-type]
+    type(None): PyTreeNodeRegistryEntry(type(None), _none_flatten, _none_unflatten),  # type: ignore[arg-type]
+    tuple: PyTreeNodeRegistryEntry(tuple, _tuple_flatten, _tuple_unflatten),  # type: ignore[arg-type]
+    list: PyTreeNodeRegistryEntry(list, _list_flatten, _list_unflatten),  # type: ignore[arg-type]
+    dict: PyTreeNodeRegistryEntry(dict, _dict_flatten, _dict_unflatten),  # type: ignore[arg-type]
+    namedtuple: PyTreeNodeRegistryEntry(namedtuple, _namedtuple_flatten, _namedtuple_unflatten),  # type: ignore[arg-type,dict-item] # noqa: PYI024
+    OrderedDict: PyTreeNodeRegistryEntry(OrderedDict, _ordereddict_flatten, _ordereddict_unflatten),  # type: ignore[arg-type]
+    defaultdict: PyTreeNodeRegistryEntry(defaultdict, _defaultdict_flatten, _defaultdict_unflatten),  # type: ignore[arg-type]
+    deque: PyTreeNodeRegistryEntry(deque, _deque_flatten, _deque_unflatten),  # type: ignore[arg-type]
+    structseq: PyTreeNodeRegistryEntry(structseq, _structseq_flatten, _structseq_unflatten),  # type: ignore[arg-type]
 }
 # pylint: enable=all
 

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import inspect
+import sys
 from collections import OrderedDict, defaultdict, deque, namedtuple
 from operator import methodcaller
 from threading import Lock
@@ -56,12 +57,18 @@ __all__ = [
 ]
 
 
-@dataclasses.dataclass(init=True, repr=True, eq=True, frozen=True)
+SLOTS = {'slots': True} if sys.version_info >= (3, 10) else {}
+
+
+@dataclasses.dataclass(init=True, repr=True, eq=True, frozen=True, **SLOTS)
 class PyTreeNodeRegistryEntry:
     type: builtins.type
     flatten_func: FlattenFunc
     unflatten_func: UnflattenFunc
     namespace: str = ''
+
+
+del SLOTS
 
 
 # pylint: disable-next=missing-class-docstring,too-few-public-methods

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -83,6 +83,8 @@ def register_pytree_node(
 ) -> type[CustomTreeNode[T]]:
     """Extend the set of types that are considered internal nodes in pytrees.
 
+    See also :func:`register_pytree_node_class` and :func:`unregister_pytree_node`.
+
     The ``namespace`` argument is used to avoid collisions that occur when different libraries
     register the same Python type with different behaviors. It is recommended to add a unique prefix
     to the namespace to avoid conflicts with other libraries. Namespaces can also be used to specify
@@ -243,6 +245,8 @@ def register_pytree_node_class(
 ) -> type[CustomTreeNode[T]] | Callable[[type[CustomTreeNode[T]]], type[CustomTreeNode[T]]]:
     """Extend the set of types that are considered internal nodes in pytrees.
 
+    See also :func:`register_pytree_node` and :func:`unregister_pytree_node`.
+
     The ``namespace`` argument is used to avoid collisions that occur when different libraries
     register the same Python type with different behaviors. It is recommended to add a unique prefix
     to the namespace to avoid conflicts with other libraries. Namespaces can also be used to specify
@@ -325,6 +329,10 @@ def unregister_pytree_node(
     namespace: str,
 ) -> PyTreeNodeRegistryEntry:
     """Remove a type from the pytree node registry.
+
+    See also :func:`register_pytree_node` and :func:`register_pytree_node_class`.
+
+    This function is the inverse operation of function :func:`register_pytree_node`.
 
     Args:
         cls (type): A Python type to remove from the pytree node registry.

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -47,6 +47,11 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
             py::arg("flatten_func"),
             py::arg("unflatten_func"),
             py::arg("namespace") = "")
+        .def("unregister_node",
+             &PyTreeTypeRegistry::Unregister,
+             "Unregister a Python type.",
+             py::arg("cls"),
+             py::arg("namespace") = "")
         .def("flatten",
              &PyTreeSpec::Flatten,
              "Flattens a pytree.",

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -217,17 +217,15 @@ template <bool NoneIsLeaf>
 /*static*/ PyTreeTypeRegistry::RegistrationPtr PyTreeTypeRegistry::Lookup(
     const py::object& cls, const std::string& registry_namespace) {
     PyTreeTypeRegistry* registry = Singleton<NoneIsLeaf>();
-    auto it = registry->m_registrations.find(cls);
-    if (it != registry->m_registrations.end()) [[likely]] {
-        return it->second;
-    }
-    if (registry_namespace.empty()) [[likely]] {
-        return nullptr;
-    } else [[unlikely]] {
+    if (!registry_namespace.empty()) [[unlikely]] {
         auto named_it =
             registry->m_named_registrations.find(std::make_pair(registry_namespace, cls));
-        return named_it != registry->m_named_registrations.end() ? named_it->second : nullptr;
+        if (named_it != registry->m_named_registrations.end()) [[likely]] {
+            return named_it->second;
+        }
     }
+    auto it = registry->m_registrations.find(cls);
+    return it != registry->m_registrations.end() ? it->second : nullptr;
 }
 
 template PyTreeTypeRegistry::RegistrationPtr PyTreeTypeRegistry::Lookup<NONE_IS_NODE>(

--- a/src/treespec/constructor.cpp
+++ b/src/treespec/constructor.cpp
@@ -72,7 +72,7 @@ template <bool NoneIsLeaf>
     auto treespecs = reserved_vector<PyTreeSpec>(4);
 
     Node node;
-    node.kind = GetKind<NoneIsLeaf>(handle, &node.custom, registry_namespace);
+    node.kind = GetKind<NoneIsLeaf>(handle, node.custom, registry_namespace);
 
     auto verify_children = [&handle, &node](const std::vector<py::object>& children,
                                             std::vector<PyTreeSpec>& treespecs,

--- a/src/treespec/flatten.cpp
+++ b/src/treespec/flatten.cpp
@@ -51,7 +51,7 @@ bool PyTreeSpec::FlattenIntoImpl(const py::handle& handle,
     if (leaf_predicate && (*leaf_predicate)(handle).cast<bool>()) [[unlikely]] {
         leaves.emplace_back(py::reinterpret_borrow<py::object>(handle));
     } else [[likely]] {
-        node.kind = GetKind<NoneIsLeaf>(handle, &node.custom, registry_namespace);
+        node.kind = GetKind<NoneIsLeaf>(handle, node.custom, registry_namespace);
         // NOLINTNEXTLINE[misc-no-recursion]
         auto recurse = [this, &found_custom, &leaf_predicate, &registry_namespace, &leaves, &depth](
                            const py::handle& child) -> void {
@@ -230,7 +230,7 @@ bool PyTreeSpec::FlattenIntoWithPathImpl(const py::handle& handle,
         leaves.emplace_back(py::reinterpret_borrow<py::object>(handle));
         paths.emplace_back(std::move(path));
     } else [[likely]] {
-        node.kind = GetKind<NoneIsLeaf>(handle, &node.custom, registry_namespace);
+        node.kind = GetKind<NoneIsLeaf>(handle, node.custom, registry_namespace);
         // NOLINTNEXTLINE[misc-no-recursion]
         auto recurse = [this,
                         &found_custom,
@@ -592,7 +592,7 @@ py::list PyTreeSpec::FlattenUpTo(const py::object& full_tree) const {
             }
 
             case PyTreeKind::Custom: {
-                const PyTreeTypeRegistry::Registration* registration = nullptr;
+                RegistrationPtr registration{nullptr};
                 if (m_none_is_leaf) [[unlikely]] {
                     registration =
                         PyTreeTypeRegistry::Lookup<NONE_IS_LEAF>(py::type::of(object), m_namespace);
@@ -654,9 +654,9 @@ template <bool NoneIsLeaf>
 /*static*/ bool PyTreeSpec::ObjectIsLeafImpl(const py::handle& handle,
                                              const std::optional<py::function>& leaf_predicate,
                                              const std::string& registry_namespace) {
-    const PyTreeTypeRegistry::Registration* custom = nullptr;
+    RegistrationPtr custom{nullptr};
     return ((leaf_predicate && (*leaf_predicate)(handle).cast<bool>()) ||
-            (GetKind<NoneIsLeaf>(handle, &custom, registry_namespace) == PyTreeKind::Leaf));
+            (GetKind<NoneIsLeaf>(handle, custom, registry_namespace) == PyTreeKind::Leaf));
 }
 
 /*static*/ bool PyTreeSpec::ObjectIsLeaf(const py::object& object,
@@ -674,12 +674,12 @@ template <bool NoneIsLeaf>
 /*static*/ bool PyTreeSpec::AllLeavesImpl(const py::iterable& iterable,
                                           const std::optional<py::function>& leaf_predicate,
                                           const std::string& registry_namespace) {
-    const PyTreeTypeRegistry::Registration* custom = nullptr;
+    RegistrationPtr custom{nullptr};
     for (const py::handle& h : iterable) {
         if (leaf_predicate && (*leaf_predicate)(h).cast<bool>()) [[unlikely]] {
             continue;
         }
-        if (GetKind<NoneIsLeaf>(h, &custom, registry_namespace) != PyTreeKind::Leaf) [[unlikely]] {
+        if (GetKind<NoneIsLeaf>(h, custom, registry_namespace) != PyTreeKind::Leaf) [[unlikely]] {
             return false;
         }
     }

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -168,19 +168,19 @@ namespace optree {
 
 template <bool NoneIsLeaf>
 /*static*/ PyTreeKind PyTreeSpec::GetKind(const py::handle& handle,
-                                          PyTreeTypeRegistry::Registration const** custom,
+                                          RegistrationPtr& custom,
                                           const std::string& registry_namespace) {
-    const PyTreeTypeRegistry::Registration* registration =
+    RegistrationPtr registration =
         PyTreeTypeRegistry::Lookup<NoneIsLeaf>(py::type::of(handle), registry_namespace);
     if (registration) [[likely]] {
         if (registration->kind == PyTreeKind::Custom) [[unlikely]] {
-            *custom = registration;
+            custom = registration;
         } else [[likely]] {
-            *custom = nullptr;
+            custom = nullptr;
         }
         return registration->kind;
     }
-    *custom = nullptr;
+    custom = nullptr;
     if (IsStructSequenceInstance(handle)) [[unlikely]] {
         return PyTreeKind::StructSequence;
     }
@@ -191,10 +191,10 @@ template <bool NoneIsLeaf>
 }
 
 template PyTreeKind PyTreeSpec::GetKind<NONE_IS_NODE>(const py::handle&,
-                                                      PyTreeTypeRegistry::Registration const**,
+                                                      RegistrationPtr&,
                                                       const std::string&);
 template PyTreeKind PyTreeSpec::GetKind<NONE_IS_LEAF>(const py::handle&,
-                                                      PyTreeTypeRegistry::Registration const**,
+                                                      RegistrationPtr&,
                                                       const std::string&);
 
 // NOLINTNEXTLINE[readability-function-cognitive-complexity]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,6 +15,7 @@
 
 # pylint: disable=missing-class-docstring,missing-function-docstring,invalid-name
 
+import gc
 import itertools
 import sys
 import time
@@ -23,6 +24,12 @@ from collections import OrderedDict, UserDict, defaultdict, deque, namedtuple
 import pytest
 
 import optree
+
+
+def getrefcount(obj=None):
+    for _ in range(10):
+        gc.collect()
+    return sys.getrefcount(obj)
 
 
 def parametrize(**argvalues) -> pytest.mark.parametrize:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -158,7 +158,7 @@ def test_register_pytree_node_with_invalid_namespace():
 def test_register_pytree_node_duplicate_builtin_namespace():
     with pytest.raises(
         ValueError,
-        match=r"PyTree type <class 'NoneType'> is already registered in the global namespace.",
+        match=r"PyTree type <class 'NoneType'> is a built-in type and cannot be re-registered.",
     ):
         optree.register_pytree_node(
             type(None),
@@ -169,7 +169,7 @@ def test_register_pytree_node_duplicate_builtin_namespace():
 
     with pytest.raises(
         ValueError,
-        match=r"PyTree type <class 'NoneType'> is already registered in the global namespace.",
+        match=r"PyTree type <class 'NoneType'> is a built-in type and cannot be re-registered.",
     ):
         optree.register_pytree_node(
             type(None),
@@ -180,7 +180,7 @@ def test_register_pytree_node_duplicate_builtin_namespace():
 
     with pytest.raises(
         ValueError,
-        match=r"PyTree type <class 'list'> is already registered in the global namespace.",
+        match=r"PyTree type <class 'list'> is a built-in type and cannot be re-registered.",
     ):
         optree.register_pytree_node(
             list,
@@ -190,7 +190,7 @@ def test_register_pytree_node_duplicate_builtin_namespace():
         )
     with pytest.raises(
         ValueError,
-        match=r"PyTree type <class 'list'> is already registered in the global namespace.",
+        match=r"PyTree type <class 'list'> is a built-in type and cannot be re-registered.",
     ):
         optree.register_pytree_node(
             list,
@@ -216,10 +216,12 @@ def test_register_pytree_node_namedtuple():
             lambda _, t: mytuple1(*reversed(t)),
             namespace=optree.registry.__GLOBAL_NAMESPACE,
         )
-    with pytest.raises(
-        ValueError,
+    with pytest.warns(
+        UserWarning,
         match=re.escape(
-            r"PyTree type <class 'test_registry.mytuple1'> is already registered in the global namespace.",
+            r"PyTree type <class 'test_registry.mytuple1'> is a subclass of `collections.namedtuple`, "
+            r'which is already registered in the global namespace. '
+            r"Override it with custom flatten/unflatten functions in namespace 'mytuple'.",
         ),
     ):
         optree.register_pytree_node(
@@ -412,3 +414,7 @@ def test_pytree_node_registry_with_init_subclass():
         str(treespec)
         == "PyTreeSpec(CustomTreeNode(MyDict[['c', 'b', 'a']], [CustomTreeNode(MyAnotherDict[['f', 'd']], [*, *]), *, (*, *)]), namespace='mydict')"
     )
+
+
+def test_unregister_pytree_node_with_no_namespace():
+    pass

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -676,13 +676,13 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
         def tree_unflatten(cls, metadata, children):
             return cls(children)
 
-    weak_ref = weakref.ref(MyList1)
-    assert weak_ref() is not None
+    wr = weakref.ref(MyList1)
+    assert wr() is not None
 
     optree.unregister_pytree_node(MyList1, namespace=optree.registry.__GLOBAL_NAMESPACE)
     del MyList1
     getrefcount(None)
-    assert weak_ref() is None
+    assert wr() is None
 
     @optree.register_pytree_node_class(namespace=optree.registry.__GLOBAL_NAMESPACE)
     class MyList2(UserList):
@@ -693,8 +693,8 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
         def tree_unflatten(cls, metadata, children):
             return cls(reversed(children))
 
-    weak_ref = weakref.ref(MyList2)
-    assert weak_ref() is not None
+    wr = weakref.ref(MyList2)
+    assert wr() is not None
 
     leaves, treespec = optree.tree_flatten(MyList2([1, 2, 3]))
     assert leaves == [3, 2, 1]
@@ -703,13 +703,13 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
     optree.unregister_pytree_node(MyList2, namespace=optree.registry.__GLOBAL_NAMESPACE)
     del MyList2
     getrefcount(None)
-    assert weak_ref() is not None
-    assert weak_ref() is treespec.type
-    assert optree.tree_unflatten(treespec, leaves) == weak_ref()([1, 2, 3])
+    assert wr() is not None
+    assert wr() is treespec.type
+    assert optree.tree_unflatten(treespec, leaves) == wr()([1, 2, 3])
 
     del treespec
     getrefcount(None)
-    assert weak_ref() is None
+    assert wr() is None
 
     @optree.register_pytree_node_class(namespace=optree.registry.__GLOBAL_NAMESPACE)
     class MyList3(UserList):
@@ -720,8 +720,8 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
         def tree_unflatten(cls, metadata, children):
             return cls(reversed(children))
 
-    weak_ref = weakref.ref(MyList3)
-    assert weak_ref() is not None
+    wr = weakref.ref(MyList3)
+    assert wr() is not None
 
     leaves, treespec = optree.tree_flatten(MyList3([1, 2, 3]), namespace='undefined')
     assert leaves == [3, 2, 1]
@@ -733,13 +733,13 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
     optree.unregister_pytree_node(MyList3, namespace=optree.registry.__GLOBAL_NAMESPACE)
     del MyList3
     getrefcount(None)
-    assert weak_ref() is not None
-    assert weak_ref() is treespec.type
-    assert optree.tree_unflatten(treespec, leaves) == weak_ref()([1, 2, 3])
+    assert wr() is not None
+    assert wr() is treespec.type
+    assert optree.tree_unflatten(treespec, leaves) == wr()([1, 2, 3])
 
     del treespec
     getrefcount(None)
-    assert weak_ref() is None
+    assert wr() is None
 
     @optree.register_pytree_node_class(namespace='mylist')
     class MyList4(UserList):
@@ -750,13 +750,13 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
         def tree_unflatten(cls, metadata, children):
             return cls(children)
 
-    weak_ref = weakref.ref(MyList4)
-    assert weak_ref() is not None
+    wr = weakref.ref(MyList4)
+    assert wr() is not None
 
     optree.unregister_pytree_node(MyList4, namespace='mylist')
     del MyList4
     getrefcount(None)
-    assert weak_ref() is None
+    assert wr() is None
 
     @optree.register_pytree_node_class(namespace='mylist')
     class MyList5(UserList):
@@ -767,8 +767,8 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
         def tree_unflatten(cls, metadata, children):
             return cls(reversed(children))
 
-    weak_ref = weakref.ref(MyList5)
-    assert weak_ref() is not None
+    wr = weakref.ref(MyList5)
+    assert wr() is not None
 
     leaves, treespec = optree.tree_flatten(MyList5([1, 2, 3]), namespace='mylist')
     assert leaves == [3, 2, 1]
@@ -779,10 +779,10 @@ def test_unregister_pytree_node_memory_leak():  # noqa: C901
     optree.unregister_pytree_node(MyList5, namespace='mylist')
     del MyList5
     getrefcount(None)
-    assert weak_ref() is not None
-    assert weak_ref() is treespec.type
-    assert optree.tree_unflatten(treespec, leaves) == weak_ref()([1, 2, 3])
+    assert wr() is not None
+    assert wr() is treespec.type
+    assert optree.tree_unflatten(treespec, leaves) == wr()([1, 2, 3])
 
     del treespec
     getrefcount(None)
-    assert weak_ref() is None
+    assert wr() is None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -226,8 +226,8 @@ def test_register_pytree_node_namedtuple():
     ):
         optree.register_pytree_node(
             mytuple1,
-            lambda t: (reversed(t), None, None),
-            lambda _, t: mytuple1(*reversed(t)),
+            lambda t: (list(t)[1::] + list(t)[:1], None, None),
+            lambda _, t: mytuple1(*(list(t)[-1:] + list(t)[:-1])),
             namespace='mytuple',
         )
 
@@ -235,6 +235,22 @@ def test_register_pytree_node_namedtuple():
     leaves1, treespec1 = optree.tree_flatten(tree1)
     assert leaves1 == [3, 2, 1]
     assert str(treespec1) == 'PyTreeSpec(CustomTreeNode(mytuple1[None], [*, *, *]))'
+    assert tree1 == optree.tree_unflatten(treespec1, leaves1)
+
+    leaves1, treespec1 = optree.tree_flatten(tree1, namespace='undefined')
+    assert leaves1 == [3, 2, 1]
+    assert (
+        str(treespec1)
+        == "PyTreeSpec(CustomTreeNode(mytuple1[None], [*, *, *]), namespace='undefined')"
+    )
+    assert tree1 == optree.tree_unflatten(treespec1, leaves1)
+
+    leaves1, treespec1 = optree.tree_flatten(tree1, namespace='mytuple')
+    assert leaves1 == [2, 3, 1]
+    assert (
+        str(treespec1)
+        == "PyTreeSpec(CustomTreeNode(mytuple1[None], [*, *, *]), namespace='mytuple')"
+    )
     assert tree1 == optree.tree_unflatten(treespec1, leaves1)
 
     mytuple2 = namedtuple('mytuple2', ['a', 'b', 'c'])  # noqa: PYI024

--- a/tests/test_treespec.py
+++ b/tests/test_treespec.py
@@ -299,7 +299,17 @@ def test_treespec_pickle_missing_registration():
             ),
         ],
     ).decode('utf-8')
-    assert 'Unknown custom type in pickled PyTreeSpec' in error
+    assert re.match(
+        r"Unknown custom type in pickled PyTreeSpec: <class '.*'> in namespace 'foo'\.",
+        string=error,
+    )
+
+    optree.unregister_pytree_node(Foo, namespace='foo')
+    with pytest.raises(
+        RuntimeError,
+        match=r"Unknown custom type in pickled PyTreeSpec: <class '.*'> in namespace 'foo'\.",
+    ):
+        treespec = pickle.loads(serialized)
 
 
 @parametrize(


### PR DESCRIPTION
## Description

Describe your changes in detail.

- Change the registration pointer in the `PyTreeSpec` object from raw pointer to shared pointer.
- Add API to unregister node type in the registry.

```python
optree.register_pytree_node(
    set,
    lambda s: (sorted(s), None, None),
    lambda _, children: set(children),
    namespace='set',
)

optree.unregister_pytree_node(set, namespace='set')
```

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Resolves #119

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
