### PR TITLE
lint: appease clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,8 @@ modernize-*,
 performance-*,
 readability-*,
 -readability-convert-member-functions-to-static,
+-readability-redundant-inline-specifier,
+-readability-redundant-member-init,
 -readability-identifier-length,
 '
 HeaderFilterRegex: '^include/.*$'

--- a/include/registry.h
+++ b/include/registry.h
@@ -19,6 +19,7 @@ limitations under the License.
 
 #include <pybind11/pybind11.h>
 
+#include <cstdint>        // std::uint8_t
 #include <memory>         // std::unique_ptr
 #include <string>         // std::string
 #include <unordered_map>  // std::unordered_map
@@ -30,7 +31,7 @@ namespace py = pybind11;
 using size_t = py::size_t;
 using ssize_t = py::ssize_t;
 
-enum class PyTreeKind {
+enum class PyTreeKind : std::uint8_t {
     Custom = 0,      // A custom type
     Leaf,            // An opaque leaf node
     None,            // None


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
