### PR TITLE
feat(registry): add context manager to temporarily set the dictionary sorting mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
           if-no-files-found: error
 
   build-wheels:
-    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    name: Build wheels for Python ${{ matrix.python-version }} on ${{ matrix.os }} (${{ matrix.archs }})
     runs-on: ${{ matrix.os }}
     needs: [build-sdist]
     if: github.repository == 'metaopt/optree' && (github.event_name != 'push' || startsWith(github.ref, 'refs/tags/'))
@@ -92,14 +92,65 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
           ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
+        archs: [
+            # Generic
+            "auto",
+            # Linux
+            "aarch64",
+            "ppc64le",
+            "s390x",
+            # Windows
+            "ARM64",
+          ]
         include:
           - os: macos-13
             python-version: "3.7"
+            archs: "auto"
         exclude:
+          - os: ubuntu-latest
+            archs: "ARM64"
+          - os: windows-latest
+            archs: "aarch64"
+          - os: windows-latest
+            archs: "ppc64le"
+          - os: windows-latest
+            archs: "s390x"
           - os: macos-latest
-            python-version: "3.7"  # Python 3.7 does not support macOS ARM64
+            archs: "aarch64"
+          - os: macos-latest
+            archs: "ppc64le"
+          - os: macos-latest
+            archs: "s390x"
+          - os: macos-latest
+            archs: "ARM64"
+          - os: ubuntu-latest
+            python-version: "pypy3.9"
+            archs: "ppc64le"
+          - os: ubuntu-latest
+            python-version: "pypy3.10"
+            archs: "ppc64le"
+          - os: ubuntu-latest
+            python-version: "pypy3.9"
+            archs: "s390x"
+          - os: ubuntu-latest
+            python-version: "pypy3.10"
+            archs: "s390x"
+          - os: windows-latest
+            python-version: "3.7"
+            archs: "ARM64"
+          - os: windows-latest
+            python-version: "3.8"
+            archs: "ARM64"
+          - os: windows-latest
+            python-version: "pypy3.9"
+            archs: "ARM64"
+          - os: windows-latest
+            python-version: "pypy3.10"
+            archs: "ARM64"
+          - os: macos-latest
+            python-version: "3.7"
       fail-fast: false
-    timeout-minutes: 240
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -139,9 +190,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.19
         env:
           CIBW_BUILD: ${{ env.CIBW_BUILD }}
-          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
-          CIBW_ARCHS_WINDOWS: auto ARM64
-          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_ARCHS_MACOS: ${{ matrix.archs }} universal2
         with:
           package-dir: .
           output-dir: wheelhouse
@@ -149,7 +199,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
+          name: wheels-${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.archs }}
           path: wheelhouse/*.whl
           if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
           - os: macos-latest
             python-version: "3.7"  # Python 3.7 does not support macOS ARM64
       fail-fast: false
-    timeout-minutes: 60
+    timeout-minutes: 240
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add context manager to temporarily set the dictionary sorting mode by [@XuehaiPan](https://github.com/XuehaiPan) in [#147](https://github.com/metaopt/optree/pull/147).
 - Add PyPy support by [@XuehaiPan](https://github.com/XuehaiPan) in [#145](https://github.com/metaopt/optree/pull/145).
 - Add 32-bit wheels for Linux and Windows by [@XuehaiPan](https://github.com/XuehaiPan) in [#141](https://github.com/metaopt/optree/pull/141).
 - Add Linux ppc64le and s390x wheels by [@XuehaiPan](https://github.com/XuehaiPan) in [#138](https://github.com/metaopt/optree/pull/138).
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `stable` tag instead of 2.12.0 for `pybind11` version by [@XuehaiPan](https://github.com/XuehaiPan) in [#146](https://github.com/metaopt/optree/pull/146).
 - Refactor the raw import statement in `setup.py` with `importlib` utilities by [@XuehaiPan](https://github.com/XuehaiPan) in [#135](https://github.com/metaopt/optree/pull/135).
 - Update minimal version of `typing-extensions` to 4.5.0 for `typing_extensions.deprecated` by [@XuehaiPan](https://github.com/XuehaiPan) in [#134](https://github.com/metaopt/optree/pull/134).
 - Update string representation for `OrderedDict` by [@XuehaiPan](https://github.com/XuehaiPan) in [#133](https://github.com/metaopt/optree/pull/133).

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ pytest: pytest-install
 	$(PYTHON) -m pytest --version
 	cd tests && $(PYTHON) -X dev -c 'import $(PROJECT_PATH)' && \
 	$(PYTHON) -X dev -c 'import $(PROJECT_PATH)._C; print(f"GLIBCXX_USE_CXX11_ABI={$(PROJECT_PATH)._C.GLIBCXX_USE_CXX11_ABI}")' && \
-	$(PYTHON) -X dev -m pytest --verbose --color=yes \
+	$(PYTHON) -X dev -m pytest --verbose --color=yes --durations=0 --showlocals \
 		--cov="$(PROJECT_PATH)" --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing \
 		$(PYTESTOPTS) .
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ mypy: mypy-install
 
 xdoctest: xdoctest-install
 	$(PYTHON) -m xdoctest --version
-	$(PYTHON) -m xdoctest $(PROJECT_PATH)
+	$(PYTHON) -m xdoctest --global-exec "from optree import *" $(PROJECT_PATH)
 
 doctest: xdoctest
 

--- a/docs/source/ops.rst
+++ b/docs/source/ops.rst
@@ -23,6 +23,7 @@ Tree Manipulation Functions
 
 .. autosummary::
 
+    dict_insertion_ordered
     tree_flatten
     tree_flatten_with_path
     tree_flatten_with_accessor
@@ -55,6 +56,7 @@ Tree Manipulation Functions
     tree_flatten_one_level
     prefix_errors
 
+.. autofunction:: dict_insertion_ordered
 .. autofunction:: tree_flatten
 .. autofunction:: tree_flatten_with_path
 .. autofunction:: tree_flatten_with_accessor

--- a/optree/_C.pyi
+++ b/optree/_C.pyi
@@ -158,3 +158,11 @@ def unregister_node(
     cls: type[CustomTreeNode[T]],
     namespace: str = '',
 ) -> None: ...
+def is_dict_insertion_ordered(
+    namespace: str = '',
+    inherit_global_namespace: bool = True,
+) -> bool: ...
+def set_dict_insertion_ordered(
+    mode: bool,
+    namespace: str = '',
+) -> None: ...

--- a/optree/__init__.py
+++ b/optree/__init__.py
@@ -95,6 +95,7 @@ from optree.ops import (
 from optree.registry import (
     AttributeKeyPathEntry,
     GetitemKeyPathEntry,
+    dict_insertion_ordered,
     register_keypaths,
     register_pytree_node,
     register_pytree_node_class,
@@ -200,6 +201,7 @@ __all__ = [
     'register_pytree_node',
     'register_pytree_node_class',
     'unregister_pytree_node',
+    'dict_insertion_ordered',
     # Typing
     'PyTreeSpec',
     'PyTreeDef',

--- a/optree/typing.py
+++ b/optree/typing.py
@@ -163,7 +163,6 @@ class PyTree(Generic[T]):  # pylint: disable=too-few-public-methods
     """Generic PyTree type.
 
     >>> import torch
-    >>> from optree.typing import PyTree
     >>> TensorTree = PyTree[torch.Tensor]
     >>> TensorTree  # doctest: +IGNORE_WHITESPACE
     typing.Union[torch.Tensor,
@@ -249,7 +248,6 @@ class PyTreeTypeVar:
     """Type variable for PyTree.
 
     >>> import torch
-    >>> from optree.typing import PyTreeTypeVar
     >>> TensorTree = PyTreeTypeVar('TensorTree', torch.Tensor)
     >>> TensorTree  # doctest: +IGNORE_WHITESPACE
     typing.Union[torch.Tensor,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ build-frontend = "build"
 build-verbosity = 3
 container-engine = "docker"
 test-extras = ["test"]
-test-command = """make -C "{project}" test PYTHON=python"""
+test-command = '''make -C "{project}" test PYTHON=python PYTESTOPTS="--quiet --no-showlocals"'''
 
 # Linter tools #################################################################
 

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -67,6 +67,16 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
              "Unregister a Python type.",
              py::arg("cls"),
              py::arg("namespace") = "")
+        .def("is_dict_insertion_ordered",
+             &PyTreeSpec::IsDictInsertionOrdered,
+             "Return whether need to preserve the dict insertion order during flattening.",
+             py::arg("namespace") = "",
+             py::arg("inherit_global_namespace") = true)
+        .def("set_dict_insertion_ordered",
+             &PyTreeSpec::SetDictInsertionOrdered,
+             "Set whether need to preserve the dict insertion order during flattening.",
+             py::arg("mode"),
+             py::arg("namespace") = "")
         .def("flatten",
              &PyTreeSpec::Flatten,
              "Flattens a pytree.",

--- a/src/treespec/constructor.cpp
+++ b/src/treespec/constructor.cpp
@@ -167,7 +167,9 @@ template <bool NoneIsLeaf>
             py::list keys = DictKeys(dict);
             if (node.kind != PyTreeKind::OrderedDict) [[likely]] {
                 node.original_keys = py::getattr(keys, Py_Get_ID(copy))();
-                TotalOrderSort(keys);
+                if (!IsDictInsertionOrdered(registry_namespace)) [[likely]] {
+                    TotalOrderSort(keys);
+                }
             }
             for (const py::handle& key : keys) {
                 children.emplace_back(dict[key]);

--- a/src/treespec/traversal.cpp
+++ b/src/treespec/traversal.cpp
@@ -83,7 +83,7 @@ py::object PyTreeIter::NextImpl() {
             case PyTreeKind::DefaultDict: {
                 auto dict = py::reinterpret_borrow<py::dict>(object);
                 py::list keys = DictKeys(dict);
-                if (kind != PyTreeKind::OrderedDict) [[likely]] {
+                if (kind != PyTreeKind::OrderedDict && !m_is_dict_insertion_ordered) [[likely]] {
                     TotalOrderSort(keys);
                 }
                 if (PyList_Reverse(keys.ptr()) < 0) [[unlikely]] {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,6 +36,9 @@ skipif_pypy = pytest.mark.skipif(
 )
 
 
+GLOBAL_NAMESPACE = optree.registry.__GLOBAL_NAMESPACE  # pylint: disable=protected-access
+
+
 def gc_collect():
     for _ in range(3):
         gc.collect()
@@ -154,12 +157,11 @@ optree.register_pytree_node(
     lambda o: ((o.x, o.y), o.z),
     lambda z, xy: Vector3D(xy[0], xy[1], z),
     path_entry_type=Vector3DEntry,
-    namespace=optree.registry.__GLOBAL_NAMESPACE,  # pylint: disable=protected-access
+    namespace=GLOBAL_NAMESPACE,
 )
 
 
-# pylint: disable-next=protected-access
-@optree.register_pytree_node_class(namespace=optree.registry.__GLOBAL_NAMESPACE)
+@optree.register_pytree_node_class(namespace=GLOBAL_NAMESPACE)
 class Vector2D:
     def __init__(self, x, y):
         self.x = x
@@ -186,8 +188,7 @@ class Vector2D:
         return cls(*children)
 
 
-# pylint: disable-next=protected-access
-@optree.register_pytree_node_class(namespace=optree.registry.__GLOBAL_NAMESPACE)
+@optree.register_pytree_node_class(namespace=GLOBAL_NAMESPACE)
 @dataclasses.dataclass
 class MyDataclass:
     alpha: Any
@@ -207,10 +208,7 @@ class MyDataclass:
         return cls(*children)
 
 
-@optree.register_pytree_node_class(
-    path_entry_type=optree.GetAttrEntry,
-    namespace=optree.registry.__GLOBAL_NAMESPACE,  # pylint: disable=protected-access
-)
+@optree.register_pytree_node_class(path_entry_type=optree.GetAttrEntry, namespace=GLOBAL_NAMESPACE)
 @dataclasses.dataclass
 class MyOtherDataclass:
     a: Any
@@ -232,8 +230,7 @@ class MyOtherDataclass:
         return cls(a, b, c, d)
 
 
-# pylint: disable-next=protected-access
-@optree.register_pytree_node_class(namespace=optree.registry.__GLOBAL_NAMESPACE)
+@optree.register_pytree_node_class(namespace=GLOBAL_NAMESPACE)
 @dataclasses.dataclass
 class MyAnotherDataclass:
     x: Any
@@ -248,8 +245,7 @@ class MyAnotherDataclass:
         return cls(*children)
 
 
-# pylint: disable-next=protected-access
-@optree.register_pytree_node_class(namespace=optree.registry.__GLOBAL_NAMESPACE)
+@optree.register_pytree_node_class(namespace=GLOBAL_NAMESPACE)
 class FlatCache:
     TREE_PATH_ENTRY_TYPE = optree.GetItemEntry
 
@@ -288,9 +284,7 @@ class FlatCache:
         return cls(structured=None, leaves=children, treespec=metadata)
 
 
-@optree.register_pytree_node_class(
-    namespace=optree.registry.__GLOBAL_NAMESPACE,  # pylint: disable=protected-access
-)
+@optree.register_pytree_node_class(namespace=GLOBAL_NAMESPACE)
 class MyDict(UserDict):
     TREE_PATH_ENTRY_TYPE = optree.MappingEntry
 

--- a/tests/test_functools.py
+++ b/tests/test_functools.py
@@ -18,7 +18,7 @@
 import functools
 
 import optree
-from helpers import parametrize
+from helpers import GLOBAL_NAMESPACE, parametrize
 
 
 def dummy_func(*args, **kwargs):  # pylint: disable=unused-argument
@@ -38,13 +38,27 @@ dummy_partial_func = functools.partial(dummy_func, a=1)
         optree.functools.partial(dummy_partial_func, 1, 2, 3, x=4, y=5),
     ],
     none_is_leaf=[False, True],
+    namespace=['', 'undefined', 'namespace'],
+    dict_should_be_sorted=[False, True],
+    dict_session_namespace=['', 'undefined', 'namespace'],
 )
-def test_partial_round_trip(tree, none_is_leaf):
-    leaves, treespec = optree.tree_flatten(tree, none_is_leaf=none_is_leaf)
-    actual = optree.tree_unflatten(treespec, leaves)
-    assert actual.func == tree.func
-    assert actual.args == tree.args
-    assert actual.keywords == tree.keywords
+def test_partial_round_trip(
+    tree,
+    none_is_leaf,
+    namespace,
+    dict_should_be_sorted,
+    dict_session_namespace,
+):
+    with optree.dict_insertion_ordered(
+        not dict_should_be_sorted,
+        namespace=dict_session_namespace or GLOBAL_NAMESPACE,
+    ):
+        leaves, treespec = optree.tree_flatten(tree, none_is_leaf=none_is_leaf, namespace=namespace)
+        actual = optree.tree_unflatten(treespec, leaves)
+        assert actual.func == tree.func
+        assert actual.args == tree.args
+        assert actual.keywords == tree.keywords
+        assert tuple(actual.keywords.items()) == tuple(tree.keywords.items())
 
 
 def test_partial_does_not_merge_with_other_partials():
@@ -78,13 +92,27 @@ def test_partial_func_attribute_has_stable_hash():
         optree.Partial(dummy_partial_func, 1, 2, 3, x=4, y=5),
     ],
     none_is_leaf=[False, True],
+    namespace=['', 'undefined', 'namespace'],
+    dict_should_be_sorted=[False, True],
+    dict_session_namespace=['', 'undefined', 'namespace'],
 )
-def test_Partial_round_trip(tree, none_is_leaf):  # noqa: N802
-    leaves, treespec = optree.tree_flatten(tree, none_is_leaf=none_is_leaf)
-    actual = optree.tree_unflatten(treespec, leaves)
-    assert actual.func == tree.func
-    assert actual.args == tree.args
-    assert actual.keywords == tree.keywords
+def test_Partial_round_trip(  # noqa: N802
+    tree,
+    none_is_leaf,
+    namespace,
+    dict_should_be_sorted,
+    dict_session_namespace,
+):
+    with optree.dict_insertion_ordered(
+        not dict_should_be_sorted,
+        namespace=dict_session_namespace or GLOBAL_NAMESPACE,
+    ):
+        leaves, treespec = optree.tree_flatten(tree, none_is_leaf=none_is_leaf, namespace=namespace)
+        actual = optree.tree_unflatten(treespec, leaves)
+        assert actual.func == tree.func
+        assert actual.args == tree.args
+        assert actual.keywords == tree.keywords
+        assert tuple(actual.keywords.items()) == tuple(tree.keywords.items())
 
 
 def test_Partial_does_not_merge_with_other_partials():  # noqa: N802


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
