### PR TITLE
fix: fix warning regression during import when launch with strict warning filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fix warning regression during import when launch with strict warning filters by [@XuehaiPan](https://github.com/XuehaiPan) in [#149](https://github.com/metaopt/optree/pull/149).
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -114,8 +114,8 @@ addlicense-install: go-install
 
 pytest: pytest-install
 	$(PYTHON) -m pytest --version
-	cd tests && $(PYTHON) -X dev -c 'import $(PROJECT_PATH)' && \
-	$(PYTHON) -X dev -c 'import $(PROJECT_PATH)._C; print(f"GLIBCXX_USE_CXX11_ABI={$(PROJECT_PATH)._C.GLIBCXX_USE_CXX11_ABI}")' && \
+	cd tests && $(PYTHON) -X dev -W 'always' -W 'error' -c 'import $(PROJECT_PATH)' && \
+	$(PYTHON) -X dev -W 'always' -W 'error' -c 'import $(PROJECT_PATH)._C; print(f"GLIBCXX_USE_CXX11_ABI={$(PROJECT_PATH)._C.GLIBCXX_USE_CXX11_ABI}")' && \
 	$(PYTHON) -X dev -m pytest --verbose --color=yes --durations=0 --showlocals \
 		--cov="$(PROJECT_PATH)" --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing \
 		$(PYTESTOPTS) .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ build-frontend = "build"
 build-verbosity = 3
 container-engine = "docker"
 test-extras = ["test"]
-test-command = '''make -C "{project}" test PYTHON=python PYTESTOPTS="--quiet --no-showlocals"'''
+test-command = '''make -C "{project}" test PYTHON=python PYTESTOPTS="--quiet --exitfirst --no-showlocals"'''
 
 # Linter tools #################################################################
 
@@ -263,6 +263,7 @@ ban-relative-imports = "all"
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
+    "always",
     "ignore:The class `optree.Partial` is deprecated and will be removed in a future version. Please use `optree.functools.partial` instead.:FutureWarning",
     "ignore:The key path API is deprecated and will be removed in a future version. Please use the accessor API instead.:FutureWarning",
 ]

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -21,6 +21,8 @@ import itertools
 import operator
 import pickle
 import re
+import subprocess
+import sys
 from collections import OrderedDict, defaultdict, deque
 
 import pytest
@@ -44,6 +46,25 @@ from helpers import (
     never,
     parametrize,
 )
+
+
+def test_import_no_warnings():
+    assert (
+        subprocess.check_output(
+            [
+                sys.executable,
+                '-W',
+                'always',
+                '-W',
+                'error',
+                '-c',
+                'import optree',
+            ],
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        == ''
+    )
 
 
 def test_max_depth():


### PR DESCRIPTION
## Description

Describe your changes in detail.

Move global warning filters into a `warnings.catch_warnings()` context.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Resolves #148

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
