### PR TITLE
refactor(cmake): use `cmake`'s `FindPython` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Use `cmake`'s `FindPython` module by [@XuehaiPan](https://github.com/XuehaiPan) in [#151](https://github.com/metaopt/optree/pull/151).
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-cmake_minimum_required(VERSION 3.11)  # for FetchContent
+cmake_minimum_required(VERSION 3.18)
 project(optree LANGUAGES CXX)
 
 include(FetchContent)
@@ -123,52 +123,54 @@ function(system)
     endif()
 endfunction()
 
-if(NOT DEFINED PYTHON_EXECUTABLE)
+if(NOT DEFINED Python_EXECUTABLE)
     if(WIN32)
-        set(PYTHON_EXECUTABLE "python.exe")
+        set(Python_EXECUTABLE "python.exe")
     else()
-        set(PYTHON_EXECUTABLE "python")
+        set(Python_EXECUTABLE "python")
     endif()
 endif()
 
 if(UNIX)
     system(
-        STRIP OUTPUT_VARIABLE PYTHON_EXECUTABLE
-        COMMAND bash -c "type -P '${PYTHON_EXECUTABLE}'"
+        STRIP OUTPUT_VARIABLE Python_EXECUTABLE
+        COMMAND bash -c "type -P '${Python_EXECUTABLE}'"
     )
 endif()
 
 system(
-    STRIP OUTPUT_VARIABLE PYTHON_VERSION
-    COMMAND "${PYTHON_EXECUTABLE}" -c "print('.'.join(map(str, __import__('sys').version_info[:3])))"
+    STRIP OUTPUT_VARIABLE Python_VERSION
+    COMMAND "${Python_EXECUTABLE}" -c "print('.'.join(map(str, __import__('sys').version_info[:3])))"
 )
 
-message(STATUS "Use Python version: ${PYTHON_VERSION}")
-message(STATUS "Use Python executable: \"${PYTHON_EXECUTABLE}\"")
+message(STATUS "Use Python version: ${Python_VERSION}")
+message(STATUS "Use Python executable: \"${Python_EXECUTABLE}\"")
 
-if(NOT DEFINED PYTHON_INCLUDE_DIR)
+unset(Python_INCLUDE_DIR)
+if(NOT DEFINED Python_INCLUDE_DIR)
     message(STATUS "Auto detecting Python include directory...")
     system(
-        STRIP OUTPUT_VARIABLE PYTHON_INCLUDE_DIR
-        COMMAND "${PYTHON_EXECUTABLE}" -c "print(__import__('sysconfig').get_path('platinclude'))"
+        STRIP OUTPUT_VARIABLE Python_INCLUDE_DIR
+        COMMAND "${Python_EXECUTABLE}" -c "print(__import__('sysconfig').get_path('platinclude'))"
     )
 endif()
 
-if("${PYTHON_INCLUDE_DIR}" STREQUAL "")
+if("${Python_INCLUDE_DIR}" STREQUAL "")
     message(FATAL_ERROR "Python include directory not found")
 else()
-    message(STATUS "Detected Python include directory: \"${PYTHON_INCLUDE_DIR}\"")
-    include_directories("${PYTHON_INCLUDE_DIR}")
+    message(STATUS "Detected Python include directory: \"${Python_INCLUDE_DIR}\"")
+    include_directories("${Python_INCLUDE_DIR}")
 endif()
 
 # Include pybind11
-set(PYBIND11_PYTHON_VERSION "${PYTHON_VERSION}")
+set(PYBIND11_PYTHON_VERSION "${Python_VERSION}")
+set(PYBIND11_FINDPYTHON ON)
 
 if(NOT DEFINED PYBIND11_CMAKE_DIR)
     message(STATUS "Auto detecting pybind11 CMake directory...")
     system(
         STRIP OUTPUT_VARIABLE PYBIND11_CMAKE_DIR
-        COMMAND "${PYTHON_EXECUTABLE}" -m pybind11 --cmakedir
+        COMMAND "${Python_EXECUTABLE}" -m pybind11 --cmakedir
     )
 endif()
 

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ cmake-configure: cmake-install
 	cmake -S . -B cmake-build-debug \
 		-DCMAKE_BUILD_TYPE=Debug \
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-		-DPYTHON_EXECUTABLE="$(PYTHON)" \
+		-DPython_EXECUTABLE="$(PYTHON)" \
 		-DOPTREE_CXX_WERROR="$(OPTREE_CXX_WERROR)"
 
 cmake-build: cmake-configure

--- a/conda-recipe.yaml
+++ b/conda-recipe.yaml
@@ -26,17 +26,17 @@ channels:
   - conda-forge
 
 dependencies:
-  - python = 3.11
+  - python = 3.12
   - pip
 
   # Dependency
   - typing-extensions >= 4.5.0
 
   # Build toolchain
-  - cmake >= 3.11
+  - cmake >= 3.18
   - make
   - cxx-compiler
-  - pybind11 >= 2.11.1
+  - pybind11 >= 2.13.1
 
   # Benchmark
   - pytorch::pytorch >= 2.0, < 2.4.0a0
@@ -50,35 +50,35 @@ dependencies:
   - termcolor
 
   # Documentation
-  - sphinx >= 5.2.1
+  - sphinx
   - sphinx-rtd-theme
   - sphinx-autobuild
   - sphinx-copybutton
   - sphinxcontrib-spelling
   - sphinxcontrib-bibtex
-  - sphinx-autodoc-typehints >= 1.19.2
+  - sphinx-autodoc-typehints
   - pyenchant
   - hunspell-en
   - docutils
 
   # Testing
-  - pytest
-  - pytest-cov
-  - pytest-xdist
-  - isort
+  - conda-forge::pytest
+  - conda-forge::pytest-cov
+  - conda-forge::pytest-xdist
+  - conda-forge::isort
   - conda-forge::black
-  - pylint
-  - mypy
-  - flake8
-  - flake8-bugbear
-  - flake8-comprehensions
-  - flake8-docstrings
-  - flake8-pyi
-  - flake8-simplify
-  - ruff
-  - doc8
-  - pydocstyle
-  - xdoctest
+  - conda-forge::pylint
+  - conda-forge::mypy
+  - conda-forge::flake8
+  - conda-forge::flake8-bugbear
+  - conda-forge::flake8-comprehensions
+  - conda-forge::flake8-docstrings
+  - conda-forge::flake8-pyi
+  - conda-forge::flake8-simplify
+  - conda-forge::ruff
+  - conda-forge::doc8
+  - conda-forge::pydocstyle
+  - conda-forge::xdoctest
   - conda-forge::clang-format >= 14
   - conda-forge::clang-tools >= 14  # clang-tidy
   - conda-forge::cpplint

--- a/docs/conda-recipe.yaml
+++ b/docs/conda-recipe.yaml
@@ -25,26 +25,26 @@ channels:
   - conda-forge
 
 dependencies:
-  - python = 3.11
+  - python = 3.12
   - pip
 
   # Dependency
   - typing-extensions >= 4.5.0
 
   # Build toolchain
-  - cmake >= 3.11
+  - cmake >= 3.18
   - make
   - cxx-compiler
-  - pybind11 >= 2.11.1
+  - pybind11 >= 2.13.1
 
   # Documentation
-  - sphinx >= 5.2.1
+  - sphinx
   - sphinx-rtd-theme
   - sphinx-autobuild
   - sphinx-copybutton
   - sphinxcontrib-spelling
   - sphinxcontrib-bibtex
-  - sphinx-autodoc-typehints >= 1.19.2
+  - sphinx-autodoc-typehints
   - pyenchant
   - hunspell-en
   - docutils

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 --requirement ../requirements.txt
 
-sphinx >= 5.2.1
+sphinx
 sphinx-autoapi
 sphinx-autobuild
 sphinx-copybutton
 sphinx-rtd-theme
 sphinxcontrib-bibtex
-sphinx-autodoc-typehints >= 1.19.2
+sphinx-autodoc-typehints
 docutils
 
 jax[cpu] >= 0.4.6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,13 @@ lint = [
 ]
 test = ["pytest", "pytest-cov", "pytest-xdist"]
 docs = [
-    "sphinx >= 5.2.1",
+    "sphinx",
     "sphinx-autoapi",
     "sphinx-autobuild",
     "sphinx-copybutton",
     "sphinx-rtd-theme",
     "sphinxcontrib-bibtex",
-    "sphinx-autodoc-typehints >= 1.19.2",
+    "sphinx-autodoc-typehints",
     "docutils",
     "jax[cpu]",
     "numpy",

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,8 @@ class cmake_build_ext(build_ext):  # noqa: N801
             f'-DCMAKE_BUILD_TYPE={config}',
             f'-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{config.upper()}={ext_path.parent}',
             f'-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_{config.upper()}={build_temp}',
-            f'-DPYTHON_EXECUTABLE={sys.executable}',
-            f'-DPYTHON_INCLUDE_DIR={sysconfig.get_path("platinclude")}',
+            f'-DPython_EXECUTABLE={sys.executable}',
+            f'-DPython_INCLUDE_DIR={sysconfig.get_path("platinclude")}',
         ]
 
         if platform.system() == 'Darwin':


### PR DESCRIPTION
## Description

Describe your changes in detail.

Use `Python` instead of `PYTHON` in cmake files.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
