### PR TITLE
lint(dataclasses): improve annotation for `optree.dataclasses.field()`

### DIFF
--- a/optree/dataclasses.py
+++ b/optree/dataclasses.py
@@ -153,7 +153,6 @@ _TypeT = TypeVar('_TypeT', bound=type)
 
 
 @overload  # type: ignore[no-redef]
-@dataclass_transform(field_specifiers=(field,))
 def dataclass(  # pylint: disable=too-many-arguments
     *,
     init: bool = True,
@@ -172,7 +171,6 @@ def dataclass(  # pylint: disable=too-many-arguments
 
 
 @overload
-@dataclass_transform(field_specifiers=(field,))
 def dataclass(  # pylint: disable=too-many-arguments
     cls: _TypeT,
     *,

--- a/optree/dataclasses.py
+++ b/optree/dataclasses.py
@@ -86,8 +86,8 @@ _U = TypeVar('_U')
 _TypeT = TypeVar('_TypeT', bound=type)
 
 
-@overload
-def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+@overload  # type: ignore[no-redef]
+def field(  # pylint: disable=too-many-arguments
     *,
     default: _T,
     init: bool = True,
@@ -101,7 +101,7 @@ def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-ma
 
 
 @overload
-def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+def field(  # pylint: disable=too-many-arguments
     *,
     default_factory: Callable[[], _T],
     init: bool = True,
@@ -115,7 +115,7 @@ def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-ma
 
 
 @overload
-def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+def field(  # pylint: disable=too-many-arguments
     *,
     init: bool = True,
     repr: bool = True,  # pylint: disable=redefined-builtin
@@ -127,7 +127,7 @@ def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-ma
 ) -> Any: ...
 
 
-def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+def field(  # pylint: disable=function-redefined,too-many-arguments
     *,
     default: Any = dataclasses.MISSING,
     default_factory: Any = dataclasses.MISSING,

--- a/optree/dataclasses.py
+++ b/optree/dataclasses.py
@@ -81,6 +81,52 @@ _FIELDS = '__optree_dataclass_fields__'
 _PYTREE_NODE_DEFAULT: bool = True
 
 
+_T = TypeVar('_T')
+_U = TypeVar('_U')
+_TypeT = TypeVar('_TypeT', bound=type)
+
+
+@overload
+def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+    *,
+    default: _T,
+    init: bool = True,
+    repr: bool = True,  # pylint: disable=redefined-builtin
+    hash: bool | None = None,  # pylint: disable=redefined-builtin
+    compare: bool = True,
+    metadata: dict[str, Any] | None = None,
+    kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
+    pytree_node: bool | None = None,
+) -> _T: ...
+
+
+@overload
+def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+    *,
+    default_factory: Callable[[], _T],
+    init: bool = True,
+    repr: bool = True,  # pylint: disable=redefined-builtin
+    hash: bool | None = None,  # pylint: disable=redefined-builtin
+    compare: bool = True,
+    metadata: dict[str, Any] | None = None,
+    kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
+    pytree_node: bool | None = None,
+) -> _T: ...
+
+
+@overload
+def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
+    *,
+    init: bool = True,
+    repr: bool = True,  # pylint: disable=redefined-builtin
+    hash: bool | None = None,  # pylint: disable=redefined-builtin
+    compare: bool = True,
+    metadata: dict[str, Any] | None = None,
+    kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
+    pytree_node: bool | None = None,
+) -> Any: ...
+
+
 def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-many-arguments
     *,
     default: Any = dataclasses.MISSING,
@@ -92,7 +138,7 @@ def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-ma
     metadata: dict[str, Any] | None = None,
     kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
     pytree_node: bool | None = None,
-) -> dataclasses.Field:
+) -> Any:
     """Field factory for :func:`dataclass`.
 
     This factory function is used to define the fields in a dataclass. It is similar to the field
@@ -145,11 +191,6 @@ def field(  # type: ignore[no-redef] # pylint: disable=function-redefined,too-ma
         )
 
     return dataclasses.field(**kwargs)  # pylint: disable=invalid-field-call
-
-
-_T = TypeVar('_T')
-_U = TypeVar('_U')
-_TypeT = TypeVar('_TypeT', bound=type)
 
 
 @overload  # type: ignore[no-redef]

--- a/optree/dataclasses.py
+++ b/optree/dataclasses.py
@@ -94,10 +94,11 @@ def field(  # pylint: disable=too-many-arguments
     repr: bool = True,  # pylint: disable=redefined-builtin
     hash: bool | None = None,  # pylint: disable=redefined-builtin
     compare: bool = True,
-    metadata: dict[str, Any] | None = None,
+    metadata: dict[Any, Any] | None = None,
     kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
     pytree_node: bool | None = None,
-) -> _T: ...
+) -> _T:
+    """Field factory for :func:`dataclass`."""
 
 
 @overload
@@ -108,7 +109,7 @@ def field(  # pylint: disable=too-many-arguments
     repr: bool = True,  # pylint: disable=redefined-builtin
     hash: bool | None = None,  # pylint: disable=redefined-builtin
     compare: bool = True,
-    metadata: dict[str, Any] | None = None,
+    metadata: dict[Any, Any] | None = None,
     kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
     pytree_node: bool | None = None,
 ) -> _T: ...
@@ -121,7 +122,7 @@ def field(  # pylint: disable=too-many-arguments
     repr: bool = True,  # pylint: disable=redefined-builtin
     hash: bool | None = None,  # pylint: disable=redefined-builtin
     compare: bool = True,
-    metadata: dict[str, Any] | None = None,
+    metadata: dict[Any, Any] | None = None,
     kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
     pytree_node: bool | None = None,
 ) -> Any: ...
@@ -135,7 +136,7 @@ def field(  # pylint: disable=function-redefined,too-many-arguments
     repr: bool = True,  # pylint: disable=redefined-builtin
     hash: bool | None = None,  # pylint: disable=redefined-builtin
     compare: bool = True,
-    metadata: dict[str, Any] | None = None,
+    metadata: dict[Any, Any] | None = None,
     kw_only: bool | Literal[dataclasses.MISSING] = dataclasses.MISSING,  # type: ignore[valid-type] # Python 3.10+
     pytree_node: bool | None = None,
 ) -> Any:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ typecheck.generated-members = ["numpy.*", "torch.*"]
 
 [tool.pydocstyle]
 convention = "google"
+add-ignore = ["D103"]
 
 [tool.doc8]
 max-line-length = 500

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ typecheck.generated-members = ["numpy.*", "torch.*"]
 
 [tool.pydocstyle]
 convention = "google"
-add-ignore = ["D103"]
 
 [tool.doc8]
 max-line-length = 500


### PR DESCRIPTION
## Description

Two minor fixes in dataclasses.py

- Type annotations for the `field` function have to "lie" to the typechecker to be useful in the context of declaring a dataclass. The current change copies what is used for the standard library `dataclasses.field`. (I used [this](https://github.com/python/typeshed/blob/main/stdlib/dataclasses.pyi) as a reference.)
- The spec says `@dataclass_transform` should only be used on a single overload. (See second paragraph [here](https://typing.readthedocs.io/en/latest/spec/dataclasses.html#dataclass-transform).)

## Motivation and Context

This was already discussed in [163](https://github.com/metaopt/optree/issues/163).

- [x] I have raised an issue to propose this change.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)


## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
