### PR TITLE
feat(setup): support using system CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Support using system `cmake` executable during setup by [@mgorny](https://github.com/mgorny) in [#188](https://github.com/metaopt/optree/pull/188).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Or, clone this repo and install manually:
 ```bash
 git clone --depth=1 https://github.com/metaopt/optree.git
 cd optree
+
+# export CMAKE_EXECUTABLE="/path/to/custom/cmake"
+# export CMAKE_BUILD_TYPE="Debug"
+# export pybind11_DIR="/path/to/custom/pybind11"
 pip3 install .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Package ######################################################################
 
 [build-system]
-requires = ["setuptools", "cmake >= 3.18", "pybind11 >= 2.12"]
+requires = ["setuptools", "pybind11 >= 2.12"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -136,9 +136,14 @@ def vcs_version(name, path):
 
 
 with vcs_version(name='optree.version', path=(HERE / 'optree' / 'version.py')) as version:
+    setup_requires = []
+    if shutil.which('cmake') is None:
+        setup_requires += ['cmake >= 3.18']
+
     setup(
         name='optree',
         version=version.__version__,
         cmdclass={'build_ext': cmake_build_ext},
         ext_modules=[CMakeExtension('optree._C', source_dir=HERE)],
+        setup_requires=setup_requires,
     )


### PR DESCRIPTION
## Description

Add the dependency on PyPI `cmake` package only when the system tool is not available, and use it otherwise.

## Motivation and Context

This avoids an unnecessary dependency on a third-party binary package, and improves portability by letting users benefit from downstream patching.

close #187 

- [x] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Implemented Tasks

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
