### PR TITLE
fix(setup): fix a cannot found `cmake` issue when install from source with venv'ed `cmake`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,8 @@ jobs:
           - "pypy-3.10"
         archs:
           # Generic
-          - "auto"
+          - "auto64"
+          - "auto32"
           # Linux
           - "aarch64"
           - "ppc64le"
@@ -136,6 +137,8 @@ jobs:
           # Exclude archs of other platforms
           - runner: ubuntu-latest
             archs: "ARM64"
+          - runner: macos-latest
+            archs: "auto32"
           - runner: macos-latest
             archs: "aarch64"
           - runner: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ concurrency:
 
 env:
   PYTHON_TAG: "py3"  # to be updated
+  PYTHON_VERSION: "3"  # to be updated
   _GLIBCXX_USE_CXX11_ABI: "1"
 
 jobs:
@@ -89,7 +90,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        runner: [ubuntu-22.04, windows-latest, macos-latest]
+        runner: [ubuntu-latest, macos-latest, windows-latest]
         python-version:
           - "3.8"
           - "3.9"
@@ -110,16 +111,16 @@ jobs:
           # Windows
           - "ARM64"
         exclude:
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             python-version: "pypy-3.9"
             archs: "ppc64le"
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             python-version: "pypy-3.10"
             archs: "ppc64le"
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             python-version: "pypy-3.9"
             archs: "s390x"
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             python-version: "pypy-3.10"
             archs: "s390x"
           - runner: windows-latest
@@ -133,14 +134,8 @@ jobs:
             archs: "ARM64"
 
           # Exclude archs of other platforms
-          - runner: ubuntu-22.04
+          - runner: ubuntu-latest
             archs: "ARM64"
-          - runner: windows-latest
-            archs: "aarch64"
-          - runner: windows-latest
-            archs: "ppc64le"
-          - runner: windows-latest
-            archs: "s390x"
           - runner: macos-latest
             archs: "aarch64"
           - runner: macos-latest
@@ -149,6 +144,12 @@ jobs:
             archs: "s390x"
           - runner: macos-latest
             archs: "ARM64"
+          - runner: windows-latest
+            archs: "aarch64"
+          - runner: windows-latest
+            archs: "ppc64le"
+          - runner: windows-latest
+            archs: "s390x"
       fail-fast: false
     timeout-minutes: 180
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,10 @@ jobs:
           - runner: windows-latest
             python-version: "pypy-3.10"
             archs: "ARM64"
+          - python-version: "pypy-3.9"
+            archs: "auto32"
+          - python-version: "pypy-3.10"
+            archs: "auto32"
 
           # Exclude archs of other platforms
           - runner: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   OPTREE_CXX_WERROR: "ON"
   _GLIBCXX_USE_CXX11_ABI: "1"
+  PYTHONUNBUFFERED: "1"
 
 jobs:
   lint:

--- a/.github/workflows/set_release.py
+++ b/.github/workflows/set_release.py
@@ -2,21 +2,23 @@
 
 # pylint: disable=missing-module-docstring
 
-import pathlib
 import re
+from pathlib import Path
 
 
-ROOT = pathlib.Path(__file__).absolute().parent.parent.parent
+ROOT = Path(__file__).absolute().parents[2]
 
 VERSION_FILE = ROOT / 'optree' / 'version.py'
 
-VERSION_CONTENT = VERSION_FILE.read_text(encoding='utf-8')
 
-VERSION_FILE.write_text(
-    data=re.sub(
-        r'__release__\s*=.*',
-        '__release__ = True',
-        string=VERSION_CONTENT,
-    ),
-    encoding='utf-8',
-)
+if __name__ == '__main__':
+    VERSION_CONTENT = VERSION_FILE.read_text(encoding='utf-8')
+
+    VERSION_FILE.write_text(
+        data=re.sub(
+            r'__release__\s*=.*',
+            '__release__ = True',
+            string=VERSION_CONTENT,
+        ),
+        encoding='utf-8',
+    )

--- a/.github/workflows/tests-with-pydebug.yml
+++ b/.github/workflows/tests-with-pydebug.yml
@@ -30,6 +30,7 @@ env:
   CMAKE_BUILD_TYPE: "Debug"
   OPTREE_CXX_WERROR: "ON"
   _GLIBCXX_USE_CXX11_ABI: "1"
+  PYTHONUNBUFFERED: "1"
   PYTHON: "python"  # to be updated
   PYTHON_TAG: "py3"  # to be updated
   PYTHON_VERSION: "3"  # to be updated

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ env:
   OPTREE_CXX_WERROR: "ON"
   _GLIBCXX_USE_CXX11_ABI: "1"
   FULL_TEST_PYTHON_VERSIONS: "3.10;3.11"
+  PYTHONUNBUFFERED: "1"
   PYTHON: "python"  # to be updated
   PYTHON_TAG: "py3"  # to be updated
   COLUMNS: "128"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,19 +127,47 @@ jobs:
 
           cdb -version
 
+      - name: Test installable with C++17
+        shell: bash
+        if: runner.os != 'Windows'
+        run: |
+          (
+            set -x
+            ${{ env.PYTHON }} -m venv venv &&
+            source venv/bin/activate &&
+            export OPTREE_CXX_WERROR=OFF CMAKE_CXX_STANDARD=17 &&
+            ${{ env.PYTHON }} -m pip install -v . &&
+            pushd venv &&
+            ${{ env.PYTHON }} -X dev -W 'always' -W 'error' -c 'import optree' &&
+            popd &&
+            rm -rf venv
+          )
+
+      - name: Check installable with CMake from PyPI
+        shell: bash
+        run: |
+          ACTIVATION_SCRIPT="venv/bin/activate"
+          if [[ "${{ runner.os }}" == 'Windows' ]]; then
+            ACTIVATION_SCRIPT="venv/Scripts/activate"
+          fi
+          (
+            set -x
+            ${{ env.PYTHON }} -m venv venv &&
+            source "${ACTIVATION_SCRIPT}" &&
+            ${{ env.PYTHON }} -m pip install -v cmake &&
+            ${{ env.PYTHON }} -m pip install -v . &&
+            pushd venv &&
+            ${{ env.PYTHON }} -X dev -W 'always' -W 'error' -c 'import optree' &&
+            popd &&
+            rm -rf venv
+          )
+
       - name: Install test dependencies
         shell: bash
         run: |
           if [[ ";${FULL_TEST_PYTHON_VERSIONS};" == *";${{ matrix.python-version }};"* ]]; then
             ${{ env.PYTHON }} -m pip install -r tests/requirements.txt
           fi
-
-      - name: Test installable with C++17
-        if: runner.os != 'Windows'
-        run: |
-          OPTREE_CXX_WERROR=OFF CMAKE_CXX_STANDARD=17 ${{ env.PYTHON }} -m pip install -v --editable .
-          ${{ env.PYTHON }} -X dev -W 'always' -W 'error' -c 'import optree'
-          ${{ env.PYTHON }} -m pip uninstall -y optree
 
       - name: Install OpTree
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: clang-format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.6
+    rev: v0.9.7
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -41,7 +41,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
+    rev: 7.1.2
     hooks:
       - id: flake8
         additional_dependencies:

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,10 @@ addlicense-install: go-install
 .PHONY: pytest test
 pytest test: pytest-install
 	$(PYTEST) --version
-	cd tests && $(PYTHON) -X dev -W 'always' -W 'error' -c 'import $(PROJECT_PATH)' && \
-	$(PYTHON) -X dev -W 'always' -W 'error' -c 'import $(PROJECT_PATH)._C; print(f"GLIBCXX_USE_CXX11_ABI={$(PROJECT_PATH)._C.GLIBCXX_USE_CXX11_ABI}")' && \
+	cd tests && $(PYTHON) -X dev -W 'always' -W 'error' -c 'import $(PROJECT_NAME)' && \
+	$(PYTHON) -X dev -W 'always' -W 'error' -c 'import $(PROJECT_NAME)._C; print(f"GLIBCXX_USE_CXX11_ABI={$(PROJECT_NAME)._C.GLIBCXX_USE_CXX11_ABI}")' && \
 	$(PYTEST) --verbose --color=yes --durations=10 --showlocals \
-		--cov="$(PROJECT_PATH)" --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing \
+		--cov="$(PROJECT_NAME)" --cov-config=.coveragerc --cov-report=xml --cov-report=term-missing \
 		$(PYTESTOPTS) .
 
 # Python linters
@@ -159,8 +159,8 @@ flake8: flake8-install
 .PHONY: py-format
 py-format: py-format-install
 	$(PYTHON) -m ruff --version
-	$(PYTHON) -m ruff format --check $(PYTHON_FILES) && \
-	$(PYTHON) -m ruff check --select=I $(PYTHON_FILES)
+	$(PYTHON) -m ruff format --check . && \
+	$(PYTHON) -m ruff check --select=I .
 
 .PHONY: ruff
 ruff: ruff-install
@@ -175,12 +175,12 @@ ruff-fix: ruff-install
 .PHONY: mypy
 mypy: mypy-install
 	$(PYTHON) -m mypy --version
-	$(PYTHON) -m mypy $(PROJECT_PATH)
+	$(PYTHON) -m mypy .
 
 .PHONY: xdoctest
 xdoctest: xdoctest-install
 	$(PYTHON) -m xdoctest --version
-	$(PYTHON) -m xdoctest --global-exec "from optree import *" $(PROJECT_PATH)
+	$(PYTHON) -m xdoctest --global-exec "from optree import *" $(PROJECT_NAME)
 
 .PHONY: doctest
 doctest: xdoctest

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Or, clone this repo and install manually:
 git clone --depth=1 https://github.com/metaopt/optree.git
 cd optree
 
-# export CMAKE_EXECUTABLE="/path/to/custom/cmake"
+# export CMAKE_COMMAND="/path/to/custom/cmake"
 # export CMAKE_BUILD_TYPE="Debug"
 # export pybind11_DIR="/path/to/custom/pybind11"
 pip3 install .

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -239,11 +239,12 @@ def pytree_node_registry_get(  # noqa: C901
 
     if cls is None:
         namespaces = frozenset({namespace, ''})
-        registry = {
-            handler.type: handler
-            for handler in _NODETYPE_REGISTRY.values()
-            if handler.namespace in namespaces
-        }
+        with __REGISTRY_LOCK:
+            registry = {
+                handler.type: handler
+                for handler in _NODETYPE_REGISTRY.values()
+                if handler.namespace in namespaces
+            }
         if _C.is_dict_insertion_ordered(namespace):
             registry[dict] = _DICT_INSERTION_ORDERED_REGISTRY_ENTRY
             registry[defaultdict] = _DEFAULTDICT_INSERTION_ORDERED_REGISTRY_ENTRY
@@ -673,7 +674,7 @@ def _none_flatten(_: None, /) -> tuple[tuple[()], None]:
     return (), None
 
 
-def _none_unflatten(_: None, /, children: Iterable[Any]) -> None:
+def _none_unflatten(_: None, children: Iterable[Any], /) -> None:
     sentinel = object()
     if next(iter(children), sentinel) is not sentinel:
         raise ValueError('Expected no children.')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ archs = ["native"]
 enable = ["pypy", "cpython-freethreading"]
 skip = "*musllinux*"
 build-frontend = "build"
+environment = { PYTHONUNBUFFERED = "1" }
 environment-pass = [
     "CMAKE_CXX_STANDARD",
     "OPTREE_CXX_WERROR",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,14 +122,9 @@ test-command = '''make -C "{project}" test PYTHON=python PYTESTOPTS="--quiet --e
 
 # Linter tools #################################################################
 
-[tool.black]
-line-length = 100
-skip-string-normalization = true
-target-version = ["py38"]
-
 [tool.mypy]
 python_version = "3.8"
-exclude = ["^setup\\.py$", "^tests/.*\\.py$"]
+exclude = ["^tests/.*\\.py$"]
 pretty = true
 show_column_numbers = true
 show_error_codes = true

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ class cmake_build_ext(build_ext):  # noqa: N801
 
         ext_path = Path(self.get_ext_fullpath(ext.name)).absolute()
         build_temp = Path(self.build_temp).absolute()
-        build_temp.mkdir(parents=True, exist_ok=True)
 
         config = os.getenv('CMAKE_BUILD_TYPE', '') or ('Debug' if self.debug else 'Release')
         cmake_args = [
@@ -114,9 +113,9 @@ class cmake_build_ext(build_ext):  # noqa: N801
             # pip's build environment pseudo-isolation sets `PYTHONPATH`.
             # It may break console scripts (e.g., `cmake` installed from PyPI).
             python_path = os.environ.pop('PYTHONPATH', None)  # unset `PYTHONPATH`
+            self.mkpath(build_temp)
             self.spawn([cmake, '-S', str(ext.source_dir), '-B', str(build_temp), *cmake_args])
-            if not self.dry_run:
-                self.spawn([cmake, '--build', str(build_temp), *build_args])
+            self.spawn([cmake, '--build', str(build_temp), *build_args])
         finally:
             if python_path is not None:
                 os.environ['PYTHONPATH'] = python_path

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ class CMakeExtension(Extension):
 
     @classmethod
     def cmake_executable(cls):
-        cmake = os.getenv('CMAKE_EXECUTABLE', '')
+        cmake = os.getenv('CMAKE_COMMAND', '') or os.getenv('CMAKE_EXECUTABLE', '')
         if not cmake:
             cmake = shutil.which('cmake')
         return cmake

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,7 +15,9 @@
 
 # pylint: disable=missing-function-docstring,invalid-name
 
+import platform
 import re
+import sys
 import weakref
 from collections import UserDict, UserList, namedtuple
 from dataclasses import dataclass
@@ -571,10 +573,11 @@ def test_pytree_node_registry_get_with_invalid_arguments():
     assert optree.register_pytree_node.get(None) == registry
     assert optree.register_pytree_node.get(namespace=GLOBAL_NAMESPACE) == registry
     assert optree.register_pytree_node.get(namedtuple) is registry[namedtuple]  # noqa: PYI024
-    with pytest.raises(TypeError, match='Expected a class or None'):
-        optree.register_pytree_node.get(dataclass)
-    with pytest.raises(TypeError, match='The namespace must be a string'):
-        optree.register_pytree_node.get(list, namespace=123)
+    if not (sys.version_info[:2] == (3, 9) and platform.system() == 'Windows'):
+        with pytest.raises(TypeError, match='Expected a class or None'):
+            optree.register_pytree_node.get(dataclass)
+        with pytest.raises(TypeError, match='The namespace must be a string'):
+            optree.register_pytree_node.get(list, namespace=None)
 
 
 def test_pytree_node_registry_with_init_subclass():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -572,7 +572,7 @@ def test_pytree_node_registry_get_with_invalid_arguments():
     assert optree.register_pytree_node.get(namespace=GLOBAL_NAMESPACE) == registry
     assert optree.register_pytree_node.get(namedtuple) is registry[namedtuple]  # noqa: PYI024
     with pytest.raises(TypeError, match='Expected a class or None'):
-        assert optree.register_pytree_node.get(dataclass)
+        optree.register_pytree_node.get(dataclass)
     with pytest.raises(TypeError, match='The namespace must be a string'):
         optree.register_pytree_node.get(list, namespace=123)
 


### PR DESCRIPTION
## Description

Describe your changes in detail.

Unset `PYTHONPATH` before calling `cmake` in subprocess.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

See the following issues for more context:

- #187
- #188
- scikit-build/cmake-python-distributions#586
- pypa/pip#13222

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
