### PR TITLE
fix(setup): fix a cannot found `cmake` issue when install from source without system `cmake`

### DIFF
--- a/.github/workflows/tests-with-pydebug.yml
+++ b/.github/workflows/tests-with-pydebug.yml
@@ -331,7 +331,7 @@ jobs:
               BACKTRACE_COMMAND="gdb --exec ${{ env.PYTHON }} --core '{}' -ex 'bt -full' -ex 'q'"
             elif [[ "${{ runner.os }}" == 'macOS' ]]; then
               echo "::group::Install LLDB"
-              brew install llvm --quiet
+              brew update --quiet && brew install --formula llvm --quiet
               echo "::endgroup::"
               BACKTRACE_COMMAND="lldb --file ${{ env.PYTHON }} --core '{}' -o 'bt all' -o 'q'"
             elif [[ "${{ runner.os }}" == 'Windows' ]]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,16 @@ jobs:
           )"
           echo "PYTHON_TAG=${PYTHON_TAG}" | tee -a "${GITHUB_ENV}"
 
+          echo "::group::Install CMake"
+          if [[ "${{ runner.os }}" == 'Linux' ]]; then
+            sudo apt-get update -qq && sudo apt-get install -yqq cmake
+          elif [[ "${{ runner.os }}" == 'macOS' ]]; then
+            brew update --quiet && brew install --formula cmake
+          elif [[ "${{ runner.os }}" == 'Windows' ]]; then
+            choco install cmake cmake.install --force --yes
+          fi
+          echo "::endgroup::"
+
       - name: Enable core dump generation (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -143,7 +153,18 @@ jobs:
             rm -rf venv
           )
 
-      - name: Check installable with CMake from PyPI
+      - name: Install test dependencies
+        shell: bash
+        run: |
+          if [[ ";${FULL_TEST_PYTHON_VERSIONS};" == *";${{ matrix.python-version }};"* ]]; then
+            ${{ env.PYTHON }} -m pip install -r tests/requirements.txt
+          fi
+
+      - name: Install OpTree (with system CMake)
+        run: |
+          ${{ env.PYTHON }} -m pip install -v --editable '.[test]'
+
+      - name: Check installable with CMake from PyPI (with venv'ed CMake)
         shell: bash
         run: |
           ACTIVATION_SCRIPT="venv/bin/activate"
@@ -162,16 +183,30 @@ jobs:
             rm -rf venv
           )
 
-      - name: Install test dependencies
+      - name: Check installable with CMake from PyPI (no system CMake)
         shell: bash
         run: |
-          if [[ ";${FULL_TEST_PYTHON_VERSIONS};" == *";${{ matrix.python-version }};"* ]]; then
-            ${{ env.PYTHON }} -m pip install -r tests/requirements.txt
+          if [[ "${{ runner.os }}" == 'Linux' ]]; then
+            sudo apt-get remove cmake -y
+          elif [[ "${{ runner.os }}" == 'macOS' ]]; then
+            brew uninstall cmake --force
+          elif [[ "${{ runner.os }}" == 'Windows' ]]; then
+            choco uninstall cmake cmake.install --force --yes || true
           fi
-
-      - name: Install OpTree
-        run: |
-          ${{ env.PYTHON }} -m pip install -v --editable '.[test]'
+          ACTIVATION_SCRIPT="venv/bin/activate"
+          if [[ "${{ runner.os }}" == 'Windows' ]]; then
+            ACTIVATION_SCRIPT="venv/Scripts/activate"
+          fi
+          (
+            set -x
+            ${{ env.PYTHON }} -m venv venv &&
+            source "${ACTIVATION_SCRIPT}" &&
+            ${{ env.PYTHON }} -m pip install -v . &&
+            pushd venv &&
+            ${{ env.PYTHON }} -X dev -W 'always' -W 'error' -c 'import optree' &&
+            popd &&
+            rm -rf venv
+          )
 
       - name: Test with pytest
         shell: bash
@@ -217,7 +252,7 @@ jobs:
               BACKTRACE_COMMAND="gdb --exec ${{ env.PYTHON }} --core '{}' -ex 'bt' -ex 'q'"
             elif [[ "${{ runner.os }}" == 'macOS' ]]; then
               echo "::group::Install LLDB"
-              brew install llvm --quiet
+              brew update --quiet && brew install --formula llvm --quiet
               echo "::endgroup::"
               BACKTRACE_COMMAND="lldb --file ${{ env.PYTHON }} --core '{}' -o 'bt' -o 'q'"
             elif [[ "${{ runner.os }}" == 'Windows' ]]; then


### PR DESCRIPTION
## Description

Describe your changes in detail.

A follow up fix for another environment setting after #191.

- #191

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
