### PR TITLE
chore!(registry): remove deprecated key path APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
--
+- Remove deprecated key path APIs by [@XuehaiPan](https://github.com/XuehaiPan) in [#195](https://github.com/metaopt/optree/pull/195).
 
 ------
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -6,4 +6,3 @@ API References
     :undoc-members:
     :show-inheritance:
     :noindex:
-    :exclude-members: register_keypaths, AttributeKeyPathEntry, GetitemKeyPathEntry

--- a/optree/__init__.py
+++ b/optree/__init__.py
@@ -96,10 +96,7 @@ from optree.ops import (
     treespec_tuple,
 )
 from optree.registry import (
-    AttributeKeyPathEntry,
-    GetitemKeyPathEntry,
     dict_insertion_ordered,
-    register_keypaths,
     register_pytree_node,
     register_pytree_node_class,
     unregister_pytree_node,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,5 +298,4 @@ filterwarnings = [
     "error",
     "always",
     "ignore:The class `optree.Partial` is deprecated and will be removed in a future version. Please use `optree.functools.partial` instead.:FutureWarning",
-    "ignore:The key path API is deprecated and will be removed in a future version. Please use the accessor API instead.:FutureWarning",
 ]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,7 +15,6 @@
 
 # pylint: disable=missing-function-docstring,invalid-name
 
-import platform
 import re
 import sys
 import weakref
@@ -573,7 +572,7 @@ def test_pytree_node_registry_get_with_invalid_arguments():
     assert optree.register_pytree_node.get(None) == registry
     assert optree.register_pytree_node.get(namespace=GLOBAL_NAMESPACE) == registry
     assert optree.register_pytree_node.get(namedtuple) is registry[namedtuple]  # noqa: PYI024
-    if not (sys.version_info[:2] == (3, 9) and platform.system() == 'Windows'):
+    if sys.version_info[:2] != (3, 9):
         with pytest.raises(TypeError, match='Expected a class or None'):
             optree.register_pytree_node.get(dataclass)
         with pytest.raises(TypeError, match='The namespace must be a string'):


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
