### PR TITLE
fix(tests): prepend `tests/` to `PYTHONPATH` in subprocess call in tests

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,12 +23,16 @@ import sys
 import sysconfig
 import time
 from collections import OrderedDict, UserDict, defaultdict, deque, namedtuple
+from pathlib import Path
 from typing import Any, NamedTuple
 
 import pytest
 
 import optree
 from optree.registry import __GLOBAL_NAMESPACE as GLOBAL_NAMESPACE
+
+
+TEST_ROOT = Path(__file__).absolute().parent
 
 
 PYPY = platform.python_implementation() == 'PyPy'

--- a/tests/test_treespec.py
+++ b/tests/test_treespec.py
@@ -17,6 +17,7 @@
 
 import contextlib
 import itertools
+import os
 import pickle
 import platform
 import re
@@ -35,6 +36,7 @@ from helpers import (
     GLOBAL_NAMESPACE,
     NAMESPACED_TREE,
     PYPY,
+    TEST_ROOT,
     TREE_STRINGS,
     TREES,
     MyAnotherDict,
@@ -474,6 +476,7 @@ def test_treespec_pickle_missing_registration():
     treespec = optree.tree_structure(Foo(0, 1), namespace='foo')
     serialized = pickle.dumps(treespec)
 
+    python_path = os.pathsep.join([str(TEST_ROOT), os.getenv('PYTHONPATH', '.')])
     try:
         output = subprocess.run(
             [
@@ -494,6 +497,7 @@ def test_treespec_pickle_missing_registration():
                     """,
                 ).strip(),
             ],
+            env={'PYTHONPATH': python_path},
             capture_output=True,
             check=True,
             text=True,

--- a/tests/test_treespec.py
+++ b/tests/test_treespec.py
@@ -17,7 +17,6 @@
 
 import contextlib
 import itertools
-import os
 import pickle
 import platform
 import re
@@ -476,7 +475,6 @@ def test_treespec_pickle_missing_registration():
     treespec = optree.tree_structure(Foo(0, 1), namespace='foo')
     serialized = pickle.dumps(treespec)
 
-    python_path = os.pathsep.join([str(TEST_ROOT), os.getenv('PYTHONPATH', '.')])
     try:
         output = subprocess.run(
             [
@@ -486,6 +484,8 @@ def test_treespec_pickle_missing_registration():
                     f"""
                     import pickle
                     import sys
+
+                    sys.path.insert(0, {str(TEST_ROOT)!r})
 
                     try:
                         treespec = pickle.loads({serialized!r})
@@ -497,7 +497,6 @@ def test_treespec_pickle_missing_registration():
                     """,
                 ).strip(),
             ],
-            env={'PYTHONPATH': python_path},
             capture_output=True,
             check=True,
             text=True,


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [X] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Fixes #199

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
