### PR TITLE
chore(setup): pass `build_temp` as string to `mkpath`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,7 @@ class cmake_build_ext(build_ext):  # noqa: N801
             with unset_python_path():
                 self.spawn([cmake, '--version'])  # cmake in the parent virtual environment
 
-        self.mkpath(build_temp)
+        self.mkpath(str(build_temp))
         with spawn_context():
             self.spawn([cmake, '-S', str(ext.source_dir), '-B', str(build_temp), *cmake_args])
             self.spawn([cmake, '--build', str(build_temp), *build_args])


### PR DESCRIPTION
## Description

Convert the pathlib.Path instance to a string when passing to `mkpath`

## Motivation and Context

Otherwise it may error with
> mkpath: 'name' must be a string (got PosixPath

The actual implementation of the extension class varies depending on what packages are installed, so it does not error in all environments. 

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format`. (**required**)
- [x] I have checked the code using `make lint`. (**required**)
- [x] I have ensured `make test` pass. (**required**)
