### PR TITLE
feat(pytree): add re-export API `optree.pytree.reexport(...)`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: cpplint
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.11.10
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/docs/source/pytree.rst
+++ b/docs/source/pytree.rst
@@ -6,6 +6,15 @@ PyTree Operations
 .. automodule:: optree.pytree
     :no-members:
 
+Re-export PyTree Utilities as a Sub-module
+------------------------------------------
+
+.. autosummary::
+
+    reexport
+
+.. autofunction:: reexport
+
 Tree Operations
 ---------------
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -62,6 +62,7 @@ OrderedDict
 param
 params
 pragma
+py
 pypy
 pytree
 pytreeentry

--- a/optree/__init__.py
+++ b/optree/__init__.py
@@ -238,7 +238,7 @@ NONE_IS_LEAF: bool = NONE_IS_LEAF  # literal constant
 
 
 # pylint: disable-next=fixme
-# TODO: remove this file in version 0.18.0
+# TODO: remove this function in version 0.18.0
 def __getattr__(name: str, /) -> object:  # pragma: no cover
     """Get an attribute from the module."""
     if name == 'accessor':

--- a/optree/pytree.py
+++ b/optree/pytree.py
@@ -32,6 +32,16 @@ True
 
 from __future__ import annotations
 
+import functools as _functools
+import inspect as _inspect
+import sys as _sys
+from builtins import all as _all
+from types import ModuleType as _ModuleType
+from typing import TYPE_CHECKING as _TYPE_CHECKING
+
+import optree.dataclasses as dataclasses
+import optree.functools as functools
+from optree.accessors import PyTreeEntry
 from optree.ops import tree_accessors as accessors
 from optree.ops import tree_all as all  # pylint: disable=redefined-builtin
 from optree.ops import tree_any as any  # pylint: disable=redefined-builtin
@@ -70,9 +80,15 @@ from optree.registry import dict_insertion_ordered
 from optree.registry import register_pytree_node as register_node
 from optree.registry import register_pytree_node_class as register_node_class
 from optree.registry import unregister_pytree_node as unregister_node
+from optree.typing import PyTreeKind, PyTreeSpec
+from optree.version import __version__ as __version__  # pylint: disable=useless-import-alias
 
 
 __all__ = [
+    'reexport',
+    'PyTreeSpec',
+    'PyTreeKind',
+    'PyTreeEntry',
     'flatten',
     'flatten_with_path',
     'flatten_with_accessor',
@@ -112,3 +128,239 @@ __all__ = [
     'unregister_node',
     'dict_insertion_ordered',
 ]
+
+
+if _TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+    from typing import Any, TypeVar  # pylint: disable=ungrouped-imports
+    from typing_extensions import ParamSpec  # Python 3.10+
+
+    _P = ParamSpec('_P')
+    _T = TypeVar('_T')
+
+
+class ReexportedModule(_ModuleType):
+    """A module that re-exports another module or object."""
+
+    __all__: list[str]
+    __doc__: str
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        namespace: str,
+        original: _ModuleType,
+        doc: str | None = None,
+        __all__: Iterable[str] | None = None,
+        __dir__: Iterable[str] | None = None,
+        extra_members: dict[str, Any] | None = None,
+    ) -> None:
+        doc = doc or (
+            f'Re-exports :mod:`{original.__name__}` as `:mod:`{name}` '
+            f'with namespace :const:`{namespace!r}`.'
+        )
+        super().__init__(name, doc)
+
+        if __all__ is None:
+            __all__ = {n for n in original.__all__ if n != 'reexport'}
+        __all__ = set(__all__)
+        if __dir__ is None:
+            __dir__ = {n for n in original.__dir__() if not n.startswith('_') and n != 'reexport'}
+        __dir__ = set(__dir__).intersection(__all__)
+
+        if extra_members:
+            for key, value in extra_members.items():
+                setattr(self, key, value)
+            __dir__.update(extra_members)
+
+        self.__namespace = namespace
+        self.__original = original
+        self.__all__ = sorted(__all__)
+        self.__dir = sorted(__dir__)
+
+    def __dir__(self) -> list[str]:
+        return self.__dir.copy()
+
+    def __getattr__(self, name: str, /) -> Any:
+        """Get an attribute from the re-exported module or object."""
+        if name in self.__all__:
+            attr = getattr(self.__original, name)
+            if _inspect.isfunction(attr):
+                func = self.__reexport__(attr)
+                setattr(self, name, func)
+                return func
+            if _inspect.isclass(attr):
+                setattr(self, name, attr)
+                return attr
+        raise AttributeError(f'module {self.__name__!r} has no attribute {name!r}')
+
+    def __reexport__(self, func: Callable[_P, _T], /) -> Callable[_P, _T]:
+        sig = _inspect.signature(func)
+        if 'namespace' not in sig.parameters:
+
+            @_functools.wraps(func)
+            def wrapped(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+                return func(*args, **kwargs)
+        else:
+
+            @_functools.wraps(func)
+            def wrapped(  # type: ignore[valid-type]
+                *args: _P.args,
+                namespace: str = self.__namespace,
+                **kwargs: _P.kwargs,
+            ) -> _T:
+                return func(*args, namespace=namespace, **kwargs)  # type: ignore[arg-type]
+
+            if func.__doc__:
+                wrapped.__doc__ = func.__doc__.replace(
+                    "(default: :const:`''`, i.e., the global namespace)",
+                    f'(default: :const:`{self.__namespace!r}`)',
+                )
+            wrapped.__signature__ = sig.replace(  # type: ignore[attr-defined]
+                parameters=[
+                    p if p.name != 'namespace' else p.replace(default=self.__namespace)
+                    for p in sig.parameters.values()
+                ],
+            )
+
+        if callable(getattr(func, 'get', None)):
+            wrapped.get = self.__reexport__(func.get)  # type: ignore[attr-defined]
+
+        return wrapped
+
+
+if _TYPE_CHECKING:
+    # pylint: disable-next=missing-class-docstring,too-few-public-methods
+    class ReexportedPyTreeModule(ReexportedModule):
+        __version__: str
+        functools: _ModuleType
+        dataclasses: _ModuleType
+
+        PyTreeSpec: type[PyTreeSpec] = PyTreeSpec
+        PyTreeKind: type[PyTreeKind] = PyTreeKind
+        PyTreeEntry: type[PyTreeEntry] = PyTreeEntry
+        flatten = staticmethod(flatten)
+        flatten_with_path = staticmethod(flatten_with_path)
+        flatten_with_accessor = staticmethod(flatten_with_accessor)
+        unflatten = staticmethod(unflatten)
+        iter = staticmethod(iter)
+        leaves = staticmethod(leaves)
+        structure = staticmethod(structure)
+        paths = staticmethod(paths)
+        accessors = staticmethod(accessors)
+        is_leaf = staticmethod(is_leaf)
+        map = staticmethod(map)
+        map_ = staticmethod(map_)
+        map_with_path = staticmethod(map_with_path)
+        map_with_path_ = staticmethod(map_with_path_)
+        map_with_accessor = staticmethod(map_with_accessor)
+        map_with_accessor_ = staticmethod(map_with_accessor_)
+        replace_nones = staticmethod(replace_nones)
+        partition = staticmethod(partition)
+        transpose = staticmethod(transpose)
+        transpose_map = staticmethod(transpose_map)
+        transpose_map_with_path = staticmethod(transpose_map_with_path)
+        transpose_map_with_accessor = staticmethod(transpose_map_with_accessor)
+        broadcast_prefix = staticmethod(broadcast_prefix)
+        broadcast_common = staticmethod(broadcast_common)
+        broadcast_map = staticmethod(broadcast_map)
+        broadcast_map_with_path = staticmethod(broadcast_map_with_path)
+        broadcast_map_with_accessor = staticmethod(broadcast_map_with_accessor)
+        reduce = staticmethod(reduce)
+        sum = staticmethod(sum)
+        max = staticmethod(max)
+        min = staticmethod(min)
+        all = staticmethod(all)
+        any = staticmethod(any)
+        flatten_one_level = staticmethod(flatten_one_level)
+        register_node = staticmethod(register_node)
+        register_node_class = staticmethod(register_node_class)
+        unregister_node = staticmethod(unregister_node)
+        dict_insertion_ordered = staticmethod(dict_insertion_ordered)
+
+    def reexport(*, namespace: str, module: str | None = None) -> ReexportedPyTreeModule:
+        """Re-export a pytree utility module with the given namespace as default."""
+        raise NotImplementedError('reexport() is not available in type checking mode')
+
+else:
+
+    def reexport(*, namespace: str, module: str | None = None) -> _ModuleType:  # type: ignore[misc]
+        """Re-export a pytree utility module with the given namespace as default.
+
+        >>> import optree
+        >>> pytree = optree.pytree.reexport(namespace='my-pkg', module='my_pkg.pytree')
+        >>> pytree.flatten({'a': 1, 'b': 2})
+        ([1, 2], PyTreeSpec({'a': *, 'b': *}))
+
+        This function is useful for downstream libraries that want to re-export the pytree utilities
+        with their own namespace::
+
+            # foo/__init__.py
+            import optree
+            pytree = optree.pytree.reexport(namespace='foo')
+
+            # foo/bar.py
+            from foo import pytree
+
+            @pytree.dataclasses.dataclass
+            class Bar:
+                a: int
+                b: float
+
+            print(pytree.flatten({'a': 1, 'b': 2, 'c': Bar(3, 4.0)}))
+            # Output:
+            #   ([1, 2, 3, 4.0], PyTreeSpec({'a': *, 'b': *, 'c': CustomTreeNode(Bar[()], [*, *])}, namespace='foo'))
+
+        Args:
+            namespace (str): The namespace to re-export from.
+            module (str, optional): The name of the module to re-export.
+                If not provided, defaults to ``<caller_module>.pytree``. The caller module is determined
+                by inspecting the stack frame.
+
+        Returns:
+            The re-exported module.
+        """
+        if module is None:
+            try:
+                # pylint: disable-next=protected-access
+                caller_module = _sys._getframemodulename(1) or '__main__'  # type: ignore[attr-defined]
+            except AttributeError:  # pragma: no cover
+                try:
+                    # pylint: disable-next=protected-access
+                    caller_module = _sys._getframe(1).f_globals.get('__name__', '__main__')
+                except (AttributeError, ValueError):
+                    caller_module = '__main__'
+            module = f'{caller_module}.pytree'
+        if not _all(part.isidentifier() for part in module.split('.')):
+            raise ValueError(f'invalid module name: {module!r}')
+
+        for module_name in (module, f'{module}.dataclasses', f'{module}.functools'):
+            if module_name in _sys.modules:
+                raise ValueError(f'module {module_name!r} already exists')
+
+        reexported_dataclasses = ReexportedModule(
+            f'{module}.dataclasses',
+            namespace=namespace,
+            original=dataclasses,
+        )
+        reexported_functools = ReexportedModule(
+            f'{module}.functools',
+            namespace=namespace,
+            original=functools,
+        )
+        mod: ReexportedPyTreeModule = ReexportedModule(  # type: ignore[assignment]
+            module,
+            namespace=namespace,
+            original=_sys.modules[__name__],
+            extra_members={
+                '__version__': __version__,
+                'dataclasses': reexported_dataclasses,
+                'functools': reexported_functools,
+            },
+        )
+        if module != '':
+            _sys.modules[module] = mod
+            _sys.modules[f'{module}.dataclasses'] = reexported_dataclasses
+            _sys.modules[f'{module}.functools'] = reexported_functools
+        return mod

--- a/optree/pytree.py
+++ b/optree/pytree.py
@@ -140,7 +140,7 @@ if _TYPE_CHECKING:
 
 
 class ReexportedModule(_ModuleType):
-    """A module that re-exports another module or object."""
+    """A module that re-exports APIs from another module."""
 
     __doc__: str
 
@@ -176,18 +176,20 @@ class ReexportedModule(_ModuleType):
         self.__namespace = namespace
         self.__original = original
         self.__all_set = __all__
-        self.__all = tuple(sorted(__all__))
+        self.__all = sorted(__all__)
         self.__dir = sorted(__dir__)
 
     @property
-    def __all__(self) -> tuple[str, ...]:
+    def __all__(self) -> list[str]:
+        """Return the list of attributes available in this module."""
         return self.__all
 
     def __dir__(self) -> list[str]:
+        """Return the list of attributes available in this module."""
         return self.__dir.copy()
 
     def __getattr__(self, name: str, /) -> Any:
-        """Get an attribute from the re-exported module or object."""
+        """Get an attribute from the re-exported module."""
         if name in self.__all_set:
             attr = getattr(self.__original, name)
             if _inspect.isfunction(attr):
@@ -200,6 +202,7 @@ class ReexportedModule(_ModuleType):
         raise AttributeError(f'module {self.__name__!r} has no attribute {name!r}')
 
     def __reexport__(self, func: Callable[_P, _T], /) -> Callable[_P, _T]:
+        """Re-export a function with the default namespace."""
         sig = _inspect.signature(func)
         if 'namespace' not in sig.parameters:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,7 +115,7 @@ test-command = '''make -C "{project}" test PYTHON=python PYTESTOPTS="--no-cov --
 
 [tool.mypy]
 python_version = "3.9"
-exclude = ['^tests/.*\.py$']
+exclude = ['^tests/.*\.py$', '^third-party/.*$', '^(venv|\.venv)/.*$']
 pretty = true
 show_column_numbers = true
 show_error_codes = true
@@ -139,7 +139,7 @@ no_site_packages = true
 [tool.pylint]
 main.py-version = "3.9"
 main.extension-pkg-allow-list = ["optree._C"]
-main.ignore-paths = ["^_C/$", "^tests/$"]
+main.ignore-paths = ["^_C/$", "^tests/$", "^third-party/$"]
 basic.good-names = []
 design.max-args = 7
 format.max-line-length = 120

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -13,6 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 
+import importlib
+import re
+import sys
+import types
+
+import pytest
+
 import optree
 
 
@@ -30,12 +37,16 @@ def test_pytree_reexports():
         'dict_insertion_ordered',
     ]
 
+    assert optree.pytree.PyTreeSpec is optree.PyTreeSpec
+    assert optree.pytree.PyTreeKind is optree.PyTreeKind
+    assert optree.pytree.PyTreeEntry is optree.PyTreeEntry
     for name in tree_operations:
         assert getattr(optree.pytree, name) is getattr(optree, f'tree_{name}')
     assert optree.pytree.register_node is optree.register_pytree_node
     assert optree.pytree.register_node_class is optree.register_pytree_node_class
     assert optree.pytree.unregister_node is optree.unregister_pytree_node
     assert optree.pytree.dict_insertion_ordered is optree.dict_insertion_ordered
+    assert optree.pytree.__version__ == optree.__version__
 
 
 def test_treespec_reexports():
@@ -50,3 +61,110 @@ def test_treespec_reexports():
 
     for name in optree.treespec.__all__:
         assert getattr(optree.treespec, name) is getattr(optree, f'treespec_{name}')
+
+
+def test_pytree_reexport_with_invalid_module():
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module='123')
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module='abc.123')
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module='abc-def')
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module=' ')
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module=' abc')
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module='')
+
+
+def test_pytree_reexport_with_empty_module():
+    assert f'{__name__}.pytree' not in sys.modules
+    assert f'{__name__}.pytree.dataclasses' not in sys.modules
+    assert f'{__name__}.pytree.functools' not in sys.modules
+
+    with pytest.raises(ModuleNotFoundError, match=r'No module named'):
+        import test_shortcut.pytree
+    with pytest.raises(ModuleNotFoundError, match=r'No module named'):
+        import test_shortcut.pytree.dataclasses
+    with pytest.raises(ModuleNotFoundError, match=r'No module named'):
+        import test_shortcut.pytree.functools  # noqa: F401
+
+    pytree1 = optree.pytree.reexport(namespace='pytree1')
+    assert f'{__name__}.pytree' in sys.modules
+    assert f'{__name__}.pytree.dataclasses' in sys.modules
+    assert f'{__name__}.pytree.functools' in sys.modules
+    assert pytree1 is sys.modules[f'{__name__}.pytree']
+    assert pytree1.dataclasses is sys.modules[f'{__name__}.pytree.dataclasses']
+    assert pytree1.functools is sys.modules[f'{__name__}.pytree.functools']
+    assert pytree1.__name__ == f'{__name__}.pytree'
+    assert pytree1.dataclasses.__name__ == f'{__name__}.pytree.dataclasses'
+    assert pytree1.functools.__name__ == f'{__name__}.pytree.functools'
+    assert type(pytree1) is optree.pytree.ReexportedModule
+    assert type(pytree1.dataclasses) is optree.pytree.ReexportedModule
+    assert type(pytree1.functools) is optree.pytree.ReexportedModule
+    assert 'dataclasses' not in pytree1.__all__
+    assert 'functools' not in pytree1.__all__
+    assert '__version__' not in pytree1.__all__
+    assert 'reexport' not in pytree1.__all__
+    assert 'dataclasses' in dir(pytree1)
+    assert 'functools' in dir(pytree1)
+    assert '__version__' in dir(pytree1)
+    assert 'reexport' not in dir(pytree1)
+    assert pytree1.__version__ == optree.__version__
+
+    assert importlib.import_module('test_shortcut.pytree') is pytree1
+    assert importlib.import_module('test_shortcut.pytree.dataclasses') is pytree1.dataclasses
+    assert importlib.import_module('test_shortcut.pytree.functools') is pytree1.functools
+
+    with pytest.raises(ValueError, match=re.escape(f"module '{__name__}.pytree' already exists")):
+        optree.pytree.reexport(namespace='pytree2')
+
+
+def test_pytree_reexport_with_module():
+    assert 'some_package' not in sys.modules
+    assert 'some_package.pytree_mod' not in sys.modules
+    assert 'some_package.pytree_mod.dataclasses' not in sys.modules
+    assert 'some_package.pytree_mod.functools' not in sys.modules
+
+    sys.modules['some_package'] = types.ModuleType('some_package')
+
+    with pytest.raises(ModuleNotFoundError, match=r'No module named'):
+        import some_package.pytree_mod
+    with pytest.raises(ModuleNotFoundError, match=r'No module named'):
+        import some_package.pytree_mod.dataclasses
+    with pytest.raises(ModuleNotFoundError, match=r'No module named'):
+        import some_package.pytree_mod.functools  # noqa: F401
+
+    pytree3 = optree.pytree.reexport(namespace='pytree3', module='some_package.pytree_mod')
+    assert 'some_package.pytree_mod' in sys.modules
+    assert 'some_package.pytree_mod.dataclasses' in sys.modules
+    assert 'some_package.pytree_mod.functools' in sys.modules
+    assert pytree3 is sys.modules['some_package.pytree_mod']
+    assert pytree3.dataclasses is sys.modules['some_package.pytree_mod.dataclasses']
+    assert pytree3.functools is sys.modules['some_package.pytree_mod.functools']
+    assert pytree3.__name__ == 'some_package.pytree_mod'
+    assert pytree3.dataclasses.__name__ == 'some_package.pytree_mod.dataclasses'
+    assert pytree3.functools.__name__ == 'some_package.pytree_mod.functools'
+    assert type(pytree3) is optree.pytree.ReexportedModule
+    assert type(pytree3.dataclasses) is optree.pytree.ReexportedModule
+    assert type(pytree3.functools) is optree.pytree.ReexportedModule
+    assert 'dataclasses' not in pytree3.__all__
+    assert 'functools' not in pytree3.__all__
+    assert '__version__' not in pytree3.__all__
+    assert 'reexport' not in pytree3.__all__
+    assert 'dataclasses' in dir(pytree3)
+    assert 'functools' in dir(pytree3)
+    assert '__version__' in dir(pytree3)
+    assert 'reexport' not in dir(pytree3)
+    assert pytree3.__version__ == optree.__version__
+
+    assert importlib.import_module('some_package.pytree_mod') is pytree3
+    assert importlib.import_module('some_package.pytree_mod.dataclasses') is pytree3.dataclasses
+    assert importlib.import_module('some_package.pytree_mod.functools') is pytree3.functools
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("module 'some_package.pytree_mod' already exists"),
+    ):
+        optree.pytree.reexport(namespace='pytree4', module='some_package.pytree_mod')

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -17,10 +17,12 @@ import importlib
 import re
 import sys
 import types
+from collections import UserList
 
 import pytest
 
 import optree
+from helpers import GLOBAL_NAMESPACE
 
 
 def test_pytree_reexports():
@@ -63,7 +65,11 @@ def test_treespec_reexports():
         assert getattr(optree.treespec, name) is getattr(optree, f'treespec_{name}')
 
 
-def test_pytree_reexport_with_invalid_module():
+def test_pytree_reexport_with_invalid_argument():
+    with pytest.raises(TypeError, match=r'The namespace must be a string'):
+        optree.pytree.reexport(namespace=123)
+    optree.pytree.reexport(namespace='', module='some_module1')
+    optree.pytree.reexport(namespace=GLOBAL_NAMESPACE, module='some_module2')
     with pytest.raises(ValueError, match=r'invalid module name'):
         optree.pytree.reexport(namespace='some-namespace', module='')
     with pytest.raises(ValueError, match=r'invalid module name'):
@@ -78,7 +84,91 @@ def test_pytree_reexport_with_invalid_module():
         optree.pytree.reexport(namespace='some-namespace', module=' abc')
 
 
-def test_pytree_reexport_with_empty_module():
+def check_reexported_module(*, reexported, module, namespace):
+    assert reexported.__name__ == module
+    assert reexported.dataclasses.__name__ == f'{module}.dataclasses'
+    assert reexported.functools.__name__ == f'{module}.functools'
+    for mod in (reexported, reexported.dataclasses, reexported.functools):
+        assert mod.__name__ in sys.modules
+        assert mod is sys.modules[mod.__name__]
+        assert importlib.import_module(mod.__name__) is mod
+        assert type(mod) is optree.pytree.ReexportedModule
+
+    assert 'dataclasses' not in reexported.__all__
+    assert 'functools' not in reexported.__all__
+    assert '__version__' not in reexported.__all__
+    assert 'reexport' not in reexported.__all__
+    assert 'dataclasses' in dir(reexported)
+    assert 'functools' in dir(reexported)
+    assert '__version__' in dir(reexported)
+    assert 'reexport' not in dir(reexported)
+    assert reexported.__version__ == optree.__version__
+    assert reexported.PyTreeSpec is optree.PyTreeSpec
+    assert reexported.PyTreeKind is optree.PyTreeKind
+    assert reexported.PyTreeEntry is optree.PyTreeEntry
+
+    with pytest.raises(AttributeError, match=r'has no attribute'):
+        _ = reexported.not_exist
+
+    for mod in (reexported, reexported.dataclasses, reexported.functools):
+        assert set(mod.__all__).issubset(dir(mod))
+        for name in dir(mod):
+            _ = getattr(mod, name)
+
+    assert reexported.functools.partial is optree.functools.partial
+
+    @reexported.dataclasses.dataclass
+    class MyDataClass:
+        x: int
+        y: int
+        z: int
+
+    class MyList(UserList):
+        pass
+
+    reexported.register_node(
+        MyList,
+        lambda x: (reversed(x), None),
+        lambda _, x: MyList(reversed(x)),
+    )
+
+    def check_roundtrip(tree):
+        leaves, treespec = optree.tree_flatten(tree)
+        assert optree.tree_unflatten(treespec, leaves) == tree
+        leaves, treespec = optree.tree_flatten(tree, namespace=namespace)
+        assert optree.tree_unflatten(treespec, leaves) == tree
+        leaves, treespec = reexported.flatten(tree)
+        assert reexported.unflatten(treespec, leaves) == tree
+        leaves, treespec = reexported.flatten(tree, namespace='')
+        assert reexported.unflatten(treespec, leaves) == tree
+
+    assert optree.tree_leaves(MyDataClass(1, 2, 3)) == [MyDataClass(1, 2, 3)]
+    assert optree.tree_leaves(MyDataClass(1, 2, 3), namespace=namespace) == [1, 2, 3]
+    assert reexported.leaves(MyDataClass(1, 2, 3)) == [1, 2, 3]
+    assert reexported.leaves(MyDataClass(1, 2, 3), namespace='') == [MyDataClass(1, 2, 3)]
+    check_roundtrip(MyDataClass(1, 2, 3))
+    assert reexported.functools.reduce(lambda x, y: x + y, MyDataClass(1, 2, 3)) == 6
+
+    assert optree.tree_leaves(MyList([1, 2, 3, 4])) == [MyList([1, 2, 3, 4])]
+    assert optree.tree_leaves(MyList([1, 2, 3, 4]), namespace=namespace) == [4, 3, 2, 1]
+    assert reexported.leaves(MyList([1, 2, 3, 4])) == [4, 3, 2, 1]
+    assert reexported.leaves(MyList([1, 2, 3, 4]), namespace='') == [MyList([1, 2, 3, 4])]
+    check_roundtrip(MyList([1, 2, 3, 4]))
+    assert reexported.functools.reduce(lambda x, y: x + y, MyList([1, 2, 3, 4])) == 10
+
+    registrations = reexported.register_node.get()
+    global_registrations = optree.register_pytree_node.get()
+    registry = registrations[MyDataClass]
+    assert registrations == optree.register_pytree_node.get(namespace=namespace)
+    assert global_registrations == reexported.register_node.get(namespace='')
+    assert len(registrations) == len(global_registrations) + 2
+    assert registry == optree.register_pytree_node.get(MyDataClass, namespace=namespace)
+    assert optree.register_pytree_node.get(MyDataClass) is None
+    assert registry == reexported.register_node.get(MyDataClass)
+    assert reexported.register_node.get(MyDataClass, namespace='') is None
+
+
+def test_pytree_reexport_without_module():
     assert importlib.import_module('test_shortcut') is sys.modules[__name__]
 
     assert f'{__name__}.pytree' not in sys.modules
@@ -93,31 +183,11 @@ def test_pytree_reexport_with_empty_module():
         import test_shortcut.pytree.functools  # noqa: F401
 
     pytree1 = optree.pytree.reexport(namespace='pytree1')
-    assert f'{__name__}.pytree' in sys.modules
-    assert f'{__name__}.pytree.dataclasses' in sys.modules
-    assert f'{__name__}.pytree.functools' in sys.modules
-    assert pytree1 is sys.modules[f'{__name__}.pytree']
-    assert pytree1.dataclasses is sys.modules[f'{__name__}.pytree.dataclasses']
-    assert pytree1.functools is sys.modules[f'{__name__}.pytree.functools']
-    assert pytree1.__name__ == f'{__name__}.pytree'
-    assert pytree1.dataclasses.__name__ == f'{__name__}.pytree.dataclasses'
-    assert pytree1.functools.__name__ == f'{__name__}.pytree.functools'
-    assert type(pytree1) is optree.pytree.ReexportedModule
-    assert type(pytree1.dataclasses) is optree.pytree.ReexportedModule
-    assert type(pytree1.functools) is optree.pytree.ReexportedModule
-    assert 'dataclasses' not in pytree1.__all__
-    assert 'functools' not in pytree1.__all__
-    assert '__version__' not in pytree1.__all__
-    assert 'reexport' not in pytree1.__all__
-    assert 'dataclasses' in dir(pytree1)
-    assert 'functools' in dir(pytree1)
-    assert '__version__' in dir(pytree1)
-    assert 'reexport' not in dir(pytree1)
-    assert pytree1.__version__ == optree.__version__
-
-    assert importlib.import_module('test_shortcut.pytree') is pytree1
-    assert importlib.import_module('test_shortcut.pytree.dataclasses') is pytree1.dataclasses
-    assert importlib.import_module('test_shortcut.pytree.functools') is pytree1.functools
+    check_reexported_module(
+        reexported=pytree1,
+        module=f'{__name__}.pytree',
+        namespace='pytree1',
+    )
 
     with pytest.raises(ValueError, match=re.escape(f"module '{__name__}.pytree' already exists")):
         optree.pytree.reexport(namespace='pytree2')
@@ -139,31 +209,11 @@ def test_pytree_reexport_with_module():
         import some_package.pytree_mod.functools  # noqa: F401
 
     pytree3 = optree.pytree.reexport(namespace='pytree3', module='some_package.pytree_mod')
-    assert 'some_package.pytree_mod' in sys.modules
-    assert 'some_package.pytree_mod.dataclasses' in sys.modules
-    assert 'some_package.pytree_mod.functools' in sys.modules
-    assert pytree3 is sys.modules['some_package.pytree_mod']
-    assert pytree3.dataclasses is sys.modules['some_package.pytree_mod.dataclasses']
-    assert pytree3.functools is sys.modules['some_package.pytree_mod.functools']
-    assert pytree3.__name__ == 'some_package.pytree_mod'
-    assert pytree3.dataclasses.__name__ == 'some_package.pytree_mod.dataclasses'
-    assert pytree3.functools.__name__ == 'some_package.pytree_mod.functools'
-    assert type(pytree3) is optree.pytree.ReexportedModule
-    assert type(pytree3.dataclasses) is optree.pytree.ReexportedModule
-    assert type(pytree3.functools) is optree.pytree.ReexportedModule
-    assert 'dataclasses' not in pytree3.__all__
-    assert 'functools' not in pytree3.__all__
-    assert '__version__' not in pytree3.__all__
-    assert 'reexport' not in pytree3.__all__
-    assert 'dataclasses' in dir(pytree3)
-    assert 'functools' in dir(pytree3)
-    assert '__version__' in dir(pytree3)
-    assert 'reexport' not in dir(pytree3)
-    assert pytree3.__version__ == optree.__version__
-
-    assert importlib.import_module('some_package.pytree_mod') is pytree3
-    assert importlib.import_module('some_package.pytree_mod.dataclasses') is pytree3.dataclasses
-    assert importlib.import_module('some_package.pytree_mod.functools') is pytree3.functools
+    check_reexported_module(
+        reexported=pytree3,
+        module='some_package.pytree_mod',
+        namespace='pytree3',
+    )
 
     with pytest.raises(
         ValueError,

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -19,6 +19,10 @@ import optree
 def test_pytree_reexports():
     tree_operations = [name[len('tree_') :] for name in optree.__all__ if name.startswith('tree_')]
     assert optree.pytree.__all__ == [
+        'reexport',
+        'PyTreeSpec',
+        'PyTreeKind',
+        'PyTreeEntry',
         *tree_operations,
         'register_node',
         'register_node_class',

--- a/tests/test_shortcut.py
+++ b/tests/test_shortcut.py
@@ -65,20 +65,22 @@ def test_treespec_reexports():
 
 def test_pytree_reexport_with_invalid_module():
     with pytest.raises(ValueError, match=r'invalid module name'):
-        optree.pytree.reexport(namespace='some-namespace', module='123')
+        optree.pytree.reexport(namespace='some-namespace', module='')
     with pytest.raises(ValueError, match=r'invalid module name'):
-        optree.pytree.reexport(namespace='some-namespace', module='abc.123')
+        optree.pytree.reexport(namespace='some-namespace', module='123abc')
+    with pytest.raises(ValueError, match=r'invalid module name'):
+        optree.pytree.reexport(namespace='some-namespace', module='abc.123def')
     with pytest.raises(ValueError, match=r'invalid module name'):
         optree.pytree.reexport(namespace='some-namespace', module='abc-def')
     with pytest.raises(ValueError, match=r'invalid module name'):
         optree.pytree.reexport(namespace='some-namespace', module=' ')
     with pytest.raises(ValueError, match=r'invalid module name'):
         optree.pytree.reexport(namespace='some-namespace', module=' abc')
-    with pytest.raises(ValueError, match=r'invalid module name'):
-        optree.pytree.reexport(namespace='some-namespace', module='')
 
 
 def test_pytree_reexport_with_empty_module():
+    assert importlib.import_module('test_shortcut') is sys.modules[__name__]
+
     assert f'{__name__}.pytree' not in sys.modules
     assert f'{__name__}.pytree.dataclasses' not in sys.modules
     assert f'{__name__}.pytree.functools' not in sys.modules


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
