### PR TITLE
feat: implement optional `tp_clear` for class `PyTreeSpec` and `PyTreeIter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dump build-time meta-information to C extension by [@XuehaiPan](https://github.com/XuehaiPan) in [#215](https://github.com/metaopt/optree/pull/215).
 - Use `pybind11::native_enum` to create enum class `PyTreeKind` if available by [@XuehaiPan](https://github.com/XuehaiPan) in [#214](https://github.com/metaopt/optree/pull/214).
 - Enable `pybind11::smart_holder` to create class `PyTreeSpec` and `PyTreeIter` if available by [@XuehaiPan](https://github.com/XuehaiPan) in [#217](https://github.com/metaopt/optree/pull/217).
+- Implement optional `tp_clear` for class `PyTreeSpec` and `PyTreeIter` by [@XuehaiPan](https://github.com/XuehaiPan) in [#218](https://github.com/metaopt/optree/pull/218).
 
 ### Changed
 

--- a/include/optree/treespec.h
+++ b/include/optree/treespec.h
@@ -432,6 +432,9 @@ private:
     // Used in tp_traverse for GC support.
     static int PyTpTraverse(PyObject *self_base, visitproc visit, void *arg);
 
+    // Used in tp_clear for GC support.
+    static int PyTpClear(PyObject *self_base);
+
     // A set of namespaces that preserve the insertion order of the dictionary keys during
     // flattening.
     static inline std::unordered_set<std::string> sm_is_dict_insertion_ordered{};
@@ -466,7 +469,7 @@ public:
     friend void BuildModule(py::module_ &mod);  // NOLINT[runtime/references]
 
 private:
-    const py::object m_root;
+    py::object m_root;
     std::vector<std::pair<py::object, ssize_t>> m_agenda;
     const std::optional<py::function> m_leaf_predicate;
     const bool m_none_is_leaf;
@@ -481,6 +484,9 @@ private:
 
     // Used in tp_traverse for GC support.
     static int PyTpTraverse(PyObject *self_base, visitproc visit, void *arg);
+
+    // Used in tp_clear for GC support.
+    static int PyTpClear(PyObject *self_base);
 };
 
 }  // namespace optree

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -284,6 +284,7 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
                 auto* const type = &heap_type->ht_type;
                 type->tp_flags |= Py_TPFLAGS_HAVE_GC;
                 type->tp_traverse = &PyTreeSpec::PyTpTraverse;
+                type->tp_clear = &PyTreeSpec::PyTpClear;
             }),
             // NOLINTEND[readability-function-cognitive-complexity,cppcoreguidelines-avoid-do-while]
             py::module_local());
@@ -481,6 +482,7 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
                 auto* const type = &heap_type->ht_type;
                 type->tp_flags |= Py_TPFLAGS_HAVE_GC;
                 type->tp_traverse = &PyTreeIter::PyTpTraverse;
+                type->tp_clear = &PyTreeIter::PyTpClear;
             }),
             // NOLINTEND[readability-function-cognitive-complexity,cppcoreguidelines-avoid-do-while]
             py::module_local());

--- a/src/treespec/gc.cpp
+++ b/src/treespec/gc.cpp
@@ -37,7 +37,23 @@ namespace optree {
     return 0;
 }
 
-// NOLINTNEXTLINE[readability-function-cognitive-complexity]
+/*static*/ int PyTreeSpec::PyTpClear(PyObject* self_base) {
+    auto* const instance = reinterpret_cast<py::detail::instance*>(self_base);
+    if (!instance->get_value_and_holder().holder_constructed()) [[unlikely]] {
+        // The holder has not been constructed yet. Skip the traversal to avoid segmentation faults.
+        return 0;
+    }
+    auto& self = thread_safe_cast<PyTreeSpec&>(py::handle{self_base});
+    PYTREESPEC_SANITY_CHECK(self);
+    for (auto& node : self.m_traversal) {
+        Py_CLEAR(node.node_data.ptr());
+        Py_CLEAR(node.node_entries.ptr());
+        Py_CLEAR(node.original_keys.ptr());
+    }
+    self.m_traversal.clear();
+    return 0;
+}
+
 /*static*/ int PyTreeIter::PyTpTraverse(PyObject* self_base, visitproc visit, void* arg) {
     Py_VISIT(Py_TYPE(self_base));
     auto* const instance = reinterpret_cast<py::detail::instance*>(self_base);
@@ -50,6 +66,21 @@ namespace optree {
         Py_VISIT(pair.first.ptr());
     }
     Py_VISIT(self.m_root.ptr());
+    return 0;
+}
+
+/*static*/ int PyTreeIter::PyTpClear(PyObject* self_base) {
+    auto* const instance = reinterpret_cast<py::detail::instance*>(self_base);
+    if (!instance->get_value_and_holder().holder_constructed()) [[unlikely]] {
+        // The holder has not been constructed yet. Skip the traversal to avoid segmentation faults.
+        return 0;
+    }
+    auto& self = thread_safe_cast<PyTreeIter&>(py::handle{self_base});
+    for (auto& pair : self.m_agenda) {
+        Py_CLEAR(pair.first.ptr());
+    }
+    self.m_agenda.clear();
+    Py_CLEAR(self.m_root.ptr());
     return 0;
 }
 

--- a/tests/test_treespec.py
+++ b/tests/test_treespec.py
@@ -83,9 +83,6 @@ def test_treespec_construct():
                 assert 'The tree node traversal is empty.' in str(ex)
                 assert 'src/treespec/serialization.cpp' in str(ex).replace('\\', '/')
                 sys.exit(0)
-            else:
-                print('No exception was raised.', file=sys.stderr)
-                sys.exit(1)
         """,
     ).strip()
     returncode = 0


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
