### PR TITLE
fix: handle  `pybind11` macro defined as 0 instead of non-exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Handle `pybind11` macro defined as 0 instead of non-exist by [@XuehaiPan](https://github.com/XuehaiPan) in [#227](https://github.com/metaopt/optree/pull/227).
 
 ### Removed
 

--- a/include/optree/treespec.h
+++ b/include/optree/treespec.h
@@ -40,7 +40,7 @@ using size_t = py::size_t;
 using ssize_t = py::ssize_t;
 
 // The maximum depth of a pytree.
-#if defined(MS_WINDOWS) || defined(Py_DEBUG) || defined(PYPY_VERSION) ||                           \
+#if defined(Py_DEBUG) || defined(PYPY_VERSION) || defined(MS_WINDOWS) ||                           \
     (defined(__wasm__) || defined(__wasm32__) || defined(__wasm64__) || defined(__wasi__) ||       \
      defined(__EMSCRIPTEN__))
 constexpr ssize_t MAX_RECURSION_DEPTH = 500;

--- a/src/optree.cpp
+++ b/src/optree.cpp
@@ -52,6 +52,9 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
                 std::string(__FILE_RELPATH_FROM_PROJECT_ROOT__) + ")";
     mod.attr("Py_TPFLAGS_BASETYPE") = py::int_(Py_TPFLAGS_BASETYPE);
 
+    // NOLINTNEXTLINE[bugprone-macro-parentheses]
+#define NONZERO_OR_EMPTY(MACRO) ((MACRO + 0 != 0) || (0 - MACRO - 1 >= 0))
+
     // Meta information during build
     py::dict BUILDTIME_METADATA{};
     BUILDTIME_METADATA["PY_VERSION"] = py::str(PY_VERSION);
@@ -61,40 +64,43 @@ void BuildModule(py::module_& mod) {  // NOLINT[runtime/references]
     BUILDTIME_METADATA["PYPY_VERSION_NUM"] = py::int_(PYPY_VERSION_NUM);
     BUILDTIME_METADATA["PYPY_VERSION_HEX"] = py::int_(PYPY_VERSION_NUM);
 #endif
-#if defined(Py_DEBUG)
+#if defined(Py_DEBUG) && NONZERO_OR_EMPTY(Py_DEBUG)
     BUILDTIME_METADATA["Py_DEBUG"] = py::bool_(true);
 #else
     BUILDTIME_METADATA["Py_DEBUG"] = py::bool_(false);
 #endif
-#if defined(Py_GIL_DISABLED)
+#if defined(Py_GIL_DISABLED) && NONZERO_OR_EMPTY(Py_GIL_DISABLED)
     BUILDTIME_METADATA["Py_GIL_DISABLED"] = py::bool_(true);
 #else
     BUILDTIME_METADATA["Py_GIL_DISABLED"] = py::bool_(false);
 #endif
     BUILDTIME_METADATA["PYBIND11_VERSION_HEX"] = py::int_(PYBIND11_VERSION_HEX);
     BUILDTIME_METADATA["PYBIND11_INTERNALS_VERSION"] = py::int_(PYBIND11_INTERNALS_VERSION);
-#if defined(PYBIND11_HAS_NATIVE_ENUM)
+#if defined(PYBIND11_HAS_NATIVE_ENUM) && NONZERO_OR_EMPTY(PYBIND11_HAS_NATIVE_ENUM)
     BUILDTIME_METADATA["PYBIND11_HAS_NATIVE_ENUM"] = py::bool_(true);
 #else
     BUILDTIME_METADATA["PYBIND11_HAS_NATIVE_ENUM"] = py::bool_(false);
 #endif
-#if defined(PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT)
+#if defined(PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT) &&                                   \
+    NONZERO_OR_EMPTY(PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT)
     BUILDTIME_METADATA["PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT"] = py::bool_(true);
 #else
     BUILDTIME_METADATA["PYBIND11_HAS_INTERNALS_WITH_SMART_HOLDER_SUPPORT"] = py::bool_(false);
 #endif
-#if defined(PYBIND11_HAS_SUBINTERPRETER_SUPPORT)
+#if defined(PYBIND11_HAS_SUBINTERPRETER_SUPPORT) &&                                                \
+    NONZERO_OR_EMPTY(PYBIND11_HAS_SUBINTERPRETER_SUPPORT)
     BUILDTIME_METADATA["PYBIND11_HAS_SUBINTERPRETER_SUPPORT"] = py::bool_(true);
 #else
     BUILDTIME_METADATA["PYBIND11_HAS_SUBINTERPRETER_SUPPORT"] = py::bool_(false);
 #endif
-#if defined(_GLIBCXX_USE_CXX11_ABI)
-    BUILDTIME_METADATA["GLIBCXX_USE_CXX11_ABI"] =
-        // NOLINTNEXTLINE[modernize-use-bool-literals]
-        py::bool_(static_cast<bool>(_GLIBCXX_USE_CXX11_ABI));
+#if defined(_GLIBCXX_USE_CXX11_ABI) && NONZERO_OR_EMPTY(_GLIBCXX_USE_CXX11_ABI)
+    BUILDTIME_METADATA["GLIBCXX_USE_CXX11_ABI"] = py::bool_(true);
 #else
     BUILDTIME_METADATA["GLIBCXX_USE_CXX11_ABI"] = py::bool_(false);
 #endif
+
+#undef NONZERO_OR_EMPTY
+
     mod.attr("BUILDTIME_METADATA") = std::move(BUILDTIME_METADATA);
     py::exec(
         R"py(


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

Related:

- pybind/pybind11#5708

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
