### PR TITLE
feat(registry): preserve dict insertion order on `unflatten` for Python `tree_flatten_one_level` path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Preserve dict insertion order on `unflatten` for the Python `tree_flatten_one_level` path mirroring the C++ path by [@XuehaiPan](https://github.com/XuehaiPan) in [#280](https://github.com/metaopt/optree/pull/280).
 
 ### Changed
 

--- a/include/optree/pytypes.h
+++ b/include/optree/pytypes.h
@@ -548,6 +548,22 @@ inline Py_ALWAYS_INLINE py::list DictKeys(const py::dict &dict) {
     return py::reinterpret_steal<py::list>(PyDict_Keys(dict.ptr()));
 }
 
+// Equivalent to Python's `dict.fromkeys(iterable)`: returns a new `dict[Key, None]` with the
+// keys taken from `iterable` in order. When `iterable` is itself a dict, this hits CPython's
+// `dict_dict_fromkeys` fast path (contiguous bucket copy, no per-key rehash).
+inline Py_ALWAYS_INLINE py::dict DictFromKeys(const py::handle &iterable) {
+    const scoped_critical_section cs{iterable};
+    // NOLINTNEXTLINE[cppcoreguidelines-pro-type-vararg]
+    PyObject *result = PyObject_CallMethod(reinterpret_cast<PyObject *>(&PyDict_Type),
+                                           "fromkeys",
+                                           "O",
+                                           iterable.ptr());
+    if (result == nullptr) [[unlikely]] {
+        throw py::error_already_set();
+    }
+    return py::reinterpret_steal<py::dict>(result);
+}
+
 inline py::list SortedDictKeys(const py::dict &dict) {
     py::list keys = DictKeys(dict);
     TotalOrderSort(keys);

--- a/include/optree/treespec.h
+++ b/include/optree/treespec.h
@@ -293,7 +293,8 @@ private:
         // Number of leaf and interior nodes in the subtree rooted at this node.
         ssize_t num_nodes = 0;
 
-        // For a Dict or DefaultDict, contains the keys in insertion order.
+        // For a Dict or DefaultDict, captures the keys in insertion order as `dict[Key, None]`.
+        // Null-default for other node kinds. Used to preserve key order during unflattening.
         py::object original_keys{};
     };
 

--- a/optree/ops.py
+++ b/optree/ops.py
@@ -2631,7 +2631,7 @@ def tree_flatten_one_level(
     >>> children, metadata, entries
     ([1, (2, [3, 4]), None, 5], ['a', 'b', 'c', 'd'], ('a', 'b', 'c', 'd'))
     >>> unflatten_func(metadata, children)
-    {'a': 1, 'b': (2, [3, 4]), 'c': None, 'd': 5}
+    {'b': (2, [3, 4]), 'a': 1, 'c': None, 'd': 5}
     >>> children, metadata, entries, unflatten_func = tree_flatten_one_level([{'a': 1, 'b': (2, 3)}, (4, 5)])
     >>> children, metadata, entries
     ([{'a': 1, 'b': (2, 3)}, (4, 5)], None, (0, 1))

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -717,17 +717,20 @@ def dict_insertion_ordered(mode: bool, /, *, namespace: str) -> Generator[None]:
 class DictMetaData(list[KT]):
     """Metadata for ``dict`` and ``collections.defaultdict`` pytree nodes.
 
-    A :class:`list` subclass holding the dict keys in canonical (sorted) traversal order.
-    The list payload preserves backward compatibility with code that treats dict treespec metadata
-    as a plain ``list[KT]`` (e.g. iteration, indexing, equality with a plain list).
+    A :class:`list` subclass holding the dict keys in the canonical traversal order for the
+    active dict-ordering mode — sorted by default, or in ``dict.keys()`` insertion order when
+    :func:`dict_insertion_ordered` is active for the namespace. The list payload preserves
+    backward compatibility with code that treats dict treespec metadata as a plain ``list[KT]``
+    (e.g. iteration, indexing, equality with a plain list).
 
     The additional :attr:`original_keys` attribute records the keys in the original ``dict.keys()``
-    insertion order, captured before sorting at flatten time. It enables :func:`tree_unflatten` to
-    reconstruct dictionaries with their original key iteration order preserved, while children are
-    still traversed in sorted order so that equal dictionaries always flatten to the same leaves.
+    insertion order, captured before any sorting at flatten time. It enables :func:`tree_unflatten`
+    to reconstruct dictionaries with their original key iteration order preserved, while children
+    are still traversed in the canonical order so that equal dictionaries flatten to the same leaves
+    in sorted mode.
 
     This Python implementation mirrors the C++ ``Node`` data type, which stores ``node_data``
-    (sorted keys) and ``original_keys`` separately.
+    (traversal-order keys) and ``original_keys`` (insertion-order keys) separately.
     """
 
     __slots__: ClassVar[tuple[str, ...]] = ('original_keys',)

--- a/optree/registry.py
+++ b/optree/registry.py
@@ -38,6 +38,7 @@ from optree.accessors import (
     StructSequenceEntry,
 )
 from optree.typing import (
+    KT,
     Children,
     MetaData,
     PyTreeKind,
@@ -53,7 +54,7 @@ if TYPE_CHECKING:
     import builtins
     from collections.abc import Collection, Generator, Iterable
 
-    from optree.typing import KT, VT, CustomTreeNode, FlattenFunc, UnflattenFunc
+    from optree.typing import VT, CustomTreeNode, FlattenFunc, UnflattenFunc
 
     # pylint: disable-next=invalid-name
     CustomTreeNodeType = TypeVar('CustomTreeNodeType', bound=type[CustomTreeNode])
@@ -713,6 +714,60 @@ def dict_insertion_ordered(mode: bool, /, *, namespace: str) -> Generator[None]:
             _C.set_dict_insertion_ordered(prev, namespace)
 
 
+class DictMetaData(list[KT]):
+    """Metadata for ``dict`` and ``collections.defaultdict`` pytree nodes.
+
+    A :class:`list` subclass holding the dict keys in canonical (sorted) traversal order.
+    The list payload preserves backward compatibility with code that treats dict treespec metadata
+    as a plain ``list[KT]`` (e.g. iteration, indexing, equality with a plain list).
+
+    The additional :attr:`original_keys` attribute records the keys in the original ``dict.keys()``
+    insertion order, captured before sorting at flatten time. It enables :func:`tree_unflatten` to
+    reconstruct dictionaries with their original key iteration order preserved, while children are
+    still traversed in sorted order so that equal dictionaries always flatten to the same leaves.
+
+    This Python implementation mirrors the C++ ``Node`` data type, which stores ``node_data``
+    (sorted keys) and ``original_keys`` separately.
+    """
+
+    __slots__: ClassVar[tuple[str, ...]] = ('original_keys',)
+
+    original_keys: dict[KT, None]
+
+    def __init__(
+        self,
+        keys: Iterable[KT] = (),
+        /,
+        *,
+        original_keys: Iterable[KT] | None = None,
+        check_keys_consistency: bool = True,
+    ) -> None:
+        super().__init__(keys)
+        if original_keys is None:
+            self.original_keys = dict.fromkeys(self)
+        else:
+            self.original_keys = dict.fromkeys(original_keys)
+            if len(self.original_keys) != len(self):
+                raise ValueError(
+                    f'`original_keys` must have the same length as `keys`, '
+                    f'got {len(self.original_keys)} != {len(self)}.',
+                )
+            if check_keys_consistency and set(self.original_keys) != set(self):
+                raise ValueError(
+                    '`original_keys` must have the same keys as `keys`, '
+                    f'got {set(self.original_keys)} != {set(self)}.',
+                )
+
+    def __getnewargs_ex__(self, /) -> tuple[tuple[list[KT]], dict[str, Any]]:
+        return (
+            (list(self),),
+            {
+                'original_keys': list(self.original_keys),
+                'check_keys_consistency': False,
+            },
+        )
+
+
 def _sorted_items(items: Iterable[tuple[KT, VT]], /) -> list[tuple[KT, VT]]:
     return total_order_sorted(items, key=itemgetter(0))
 
@@ -745,11 +800,22 @@ def _list_unflatten(_: None, children: Iterable[T], /) -> list[T]:
 
 def _dict_flatten(dct: dict[KT, VT], /) -> tuple[tuple[VT, ...], list[KT], tuple[KT, ...]]:
     keys, values = unzip2(_sorted_items(dct.items()))
-    return values, list(keys), keys
+    return (
+        values,
+        DictMetaData(
+            keys,
+            # Passing a dict will use CPython's `dict_dict_fromkeys` fast path in `dict.fromkeys()`
+            original_keys=dct,
+            check_keys_consistency=False,
+        ),
+        keys,
+    )
 
 
-def _dict_unflatten(keys: list[KT], values: Iterable[VT], /) -> dict[KT, VT]:
-    return dict(safe_zip(keys, values))
+def _dict_unflatten(metadata: list[KT], values: Iterable[VT], /) -> dict[KT, VT]:
+    output: dict[KT, VT] = dict.fromkeys(getattr(metadata, 'original_keys', []))  # type: ignore[assignment]
+    output.update(safe_zip(metadata, values))
+    return output
 
 
 def _dict_insertion_ordered_flatten(
@@ -761,7 +827,16 @@ def _dict_insertion_ordered_flatten(
     tuple[KT, ...],
 ]:
     keys, values = unzip2(dct.items())
-    return values, list(keys), keys
+    return (
+        values,
+        DictMetaData(
+            keys,
+            # Passing a dict will use CPython's `dict_dict_fromkeys` fast path in `dict.fromkeys()`
+            original_keys=dct,
+            check_keys_consistency=False,
+        ),
+        keys,
+    )
 
 
 def _dict_insertion_ordered_unflatten(keys: list[KT], values: Iterable[VT], /) -> dict[KT, VT]:

--- a/src/treespec/constructors.cpp
+++ b/src/treespec/constructors.cpp
@@ -169,7 +169,7 @@ template <bool NoneIsLeaf>
                 node.arity = DictGetSize(dict);
                 keys = DictKeys(dict);
                 if (node.kind != PyTreeKind::OrderedDict) [[likely]] {
-                    node.original_keys = py::getattr(keys, "copy")();
+                    node.original_keys = DictFromKeys(dict);
                     if (!PyTreeTypeRegistry::IsDictInsertionOrdered(registry_namespace))
                         [[likely]] {
                         TotalOrderSort(keys);

--- a/src/treespec/flatten.cpp
+++ b/src/treespec/flatten.cpp
@@ -106,7 +106,7 @@ bool PyTreeSpec::FlattenIntoImpl(const py::handle &handle,
                     node.arity = DictGetSize(dict);
                     keys = DictKeys(dict);
                     if (node.kind != PyTreeKind::OrderedDict) [[likely]] {
-                        node.original_keys = py::getattr(keys, "copy")();
+                        node.original_keys = DictFromKeys(dict);
                         if constexpr (DictShouldBeSorted) {
                             TotalOrderSort(keys);
                         }
@@ -371,7 +371,7 @@ bool PyTreeSpec::FlattenIntoWithPathImpl(const py::handle &handle,
                 node.arity = DictGetSize(dict);
                 py::list keys = DictKeys(dict);
                 if (node.kind != PyTreeKind::OrderedDict) [[likely]] {
-                    node.original_keys = py::getattr(keys, "copy")();
+                    node.original_keys = DictFromKeys(dict);
                     if constexpr (DictShouldBeSorted) {
                         TotalOrderSort(keys);
                     }

--- a/src/treespec/serialization.cpp
+++ b/src/treespec/serialization.cpp
@@ -24,6 +24,7 @@ limitations under the License.
 #include <unordered_set>  // std::unordered_set
 
 #include "optree/optree.h"
+#include "optree/pytypes.h"
 
 namespace optree {
 
@@ -335,6 +336,7 @@ py::object PyTreeSpec::ToPickleable() const {
         const auto t = thread_safe_cast<py::tuple>(item);
         Node &node = out->m_traversal.emplace_back();
         node.kind = static_cast<PyTreeKind>(thread_safe_cast<ssize_t>(t[0]));
+        node.arity = thread_safe_cast<ssize_t>(t[1]);
         if (t.size() != 7) [[unlikely]] {
             if (t.size() == 8) [[likely]] {
                 if (t[7].is_none()) [[likely]] {
@@ -345,7 +347,7 @@ py::object PyTreeSpec::ToPickleable() const {
                 } else [[unlikely]] {
                     if (node.kind == PyTreeKind::Dict || node.kind == PyTreeKind::DefaultDict)
                         [[likely]] {
-                        node.original_keys = thread_safe_cast<py::list>(t[7]);
+                        node.original_keys = DictFromKeys(t[7]);
                     } else [[unlikely]] {
                         throw std::runtime_error("Malformed pickled PyTreeSpec.");
                     }
@@ -354,7 +356,6 @@ py::object PyTreeSpec::ToPickleable() const {
                 throw std::runtime_error("Malformed pickled PyTreeSpec.");
             }
         }
-        node.arity = thread_safe_cast<ssize_t>(t[1]);
         switch (node.kind) {
             case PyTreeKind::Leaf:
             case PyTreeKind::None:
@@ -418,6 +419,15 @@ py::object PyTreeSpec::ToPickleable() const {
         } else if (!t[3].is_none() || !t[4].is_none()) [[unlikely]] {
             throw std::runtime_error("Malformed pickled PyTreeSpec.");
         }
+        if (node.original_keys && DictGetSize(node.original_keys) != node.arity) [[unlikely]] {
+            throw std::runtime_error("Number of keys does not match arity in pickled PyTreeSpec.");
+        }
+        if (node.node_entries && !node.node_entries.is_none() &&
+            TupleGetSize(node.node_entries) != node.arity) [[unlikely]] {
+            throw std::runtime_error(
+                "Number of node entries does not match arity in pickled PyTreeSpec.");
+        }
+
         node.num_leaves = thread_safe_cast<ssize_t>(t[5]);
         node.num_nodes = thread_safe_cast<ssize_t>(t[6]);
     }

--- a/src/treespec/treespec.cpp
+++ b/src/treespec/treespec.cpp
@@ -89,8 +89,11 @@ namespace optree {
                                    ? py::reinterpret_borrow<py::list>(node.node_data)
                                    : TupleGetItemAs<py::list>(node.node_data, 1));
             if (node.original_keys) [[unlikely]] {
-                for (ssize_t i = 0; i < node.arity; ++i) {
-                    DictSetItem(dict, ListGetItem(node.original_keys, i), py::none());
+                // Seed the dict with keys in original insertion order (values default to `None`);
+                // the subsequent loop overwrites with actual children. Uses the dict-to-dict fast
+                // path since `node.original_keys` is a `dict[Key, None]`.
+                if (PyDict_Update(dict.ptr(), node.original_keys.ptr()) < 0) [[unlikely]] {
+                    throw py::error_already_set();
                 }
             }
             for (ssize_t i = 0; i < node.arity; ++i) {

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -3308,6 +3308,7 @@ def test_tree_flatten_one_level(  # noqa: C901
     dict_should_be_sorted,
     dict_session_namespace,
 ):
+    use_sorted_keys = dict_should_be_sorted or dict_session_namespace not in {'', namespace}
     with optree.dict_insertion_ordered(
         not dict_should_be_sorted,
         namespace=dict_session_namespace or GLOBAL_NAMESPACE,
@@ -3358,6 +3359,8 @@ def test_tree_flatten_one_level(  # noqa: C901
                 assert children == expected_children
                 assert output.type == one_level_treespec.type
                 assert output.kind == one_level_treespec.kind
+                reconstructed_node = unflatten_func(metadata, children)
+                assert reconstructed_node == node
                 if node_type in {type(None), tuple, list}:
                     assert metadata is None
                     if node_type is tuple:
@@ -3367,19 +3370,22 @@ def test_tree_flatten_one_level(  # noqa: C901
                     else:
                         assert node_kind == optree.PyTreeKind.NONE
                 elif node_type is dict:
-                    if dict_should_be_sorted or dict_session_namespace not in {'', namespace}:
+                    if use_sorted_keys:
                         assert metadata == sorted(node.keys())
                     else:
                         assert metadata == list(node.keys())
+                    assert list(reconstructed_node.keys()) == list(node.keys())
                     assert node_kind == optree.PyTreeKind.DICT
                 elif node_type is OrderedDict:
                     assert metadata == list(node.keys())
+                    assert list(reconstructed_node.keys()) == list(node.keys())
                     assert node_kind == optree.PyTreeKind.ORDEREDDICT
                 elif node_type is defaultdict:
-                    if dict_should_be_sorted or dict_session_namespace not in {'', namespace}:
+                    if use_sorted_keys:
                         assert metadata == (node.default_factory, sorted(node.keys()))
                     else:
                         assert metadata == (node.default_factory, list(node.keys()))
+                    assert list(reconstructed_node.keys()) == list(node.keys())
                     assert node_kind == optree.PyTreeKind.DEFAULTDICT
                 elif node_type is deque:
                     assert metadata == node.maxlen
@@ -3401,7 +3407,6 @@ def test_tree_flatten_one_level(  # noqa: C901
                     for child, entry in zip(children, entries):
                         assert node[entry] is child
 
-                assert unflatten_func(metadata, children) == node
                 if node_type is type(None):
                     assert unflatten_func(metadata, []) is None
                     with pytest.raises(ValueError, match=re.escape('Expected no children.')):

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,6 +15,8 @@
 
 # pylint: disable=missing-function-docstring,invalid-name
 
+import copy
+import pickle
 import re
 import sys
 import weakref
@@ -32,8 +34,10 @@ from helpers import (
     Py_GIL_DISABLED,
     disable_systrace,
     gc_collect,
+    parametrize,
     skipif_pypy,
 )
+from optree.registry import DictMetaData
 
 
 def test_register_pytree_node_class_with_no_namespace():
@@ -1314,3 +1318,165 @@ def test_registry_size():
     assert optree._C.get_registry_size(namespace='mylist') + 2 == initial_registry_size
     assert optree._C.get_registry_size(namespace='undefined') + 2 == initial_size
     assert len(optree.register_pytree_node.get(namespace='undefined')) == initial_size
+
+
+def test_dict_metadata_default_original_keys():
+    md1 = DictMetaData()
+    assert list(md1) == []
+    assert md1.original_keys == {}
+
+    md2 = DictMetaData(['a', 'b', 'c'])
+    assert list(md2) == ['a', 'b', 'c']
+    assert md2.original_keys == dict.fromkeys(md2)
+    assert list(md2.original_keys) == ['a', 'b', 'c']
+
+
+def test_dict_metadata_explicit_original_keys():
+    md = DictMetaData(['a', 'b', 'c'], original_keys=['c', 'a', 'b'])
+    assert list(md) == ['a', 'b', 'c']
+    assert list(md.original_keys) == ['c', 'a', 'b']
+
+
+def test_dict_metadata_accepts_single_pass_iterators():
+    md = DictMetaData(iter(['x', 'y']), original_keys=iter(['y', 'x']))
+    assert list(md) == ['x', 'y']
+    assert list(md.original_keys) == ['y', 'x']
+
+
+def test_dict_metadata_length_mismatch_raises():
+    with pytest.raises(
+        ValueError,
+        match=re.escape('`original_keys` must have the same length as `keys`'),
+    ):
+        DictMetaData(['a', 'b'], original_keys=['a', 'b', 'c'])
+
+
+def test_dict_metadata_keys_set_mismatch_raises():
+    with pytest.raises(
+        ValueError,
+        match=re.escape('`original_keys` must have the same keys as `keys`'),
+    ):
+        DictMetaData(['a', 'b'], original_keys=['a', 'c'])
+
+
+def test_dict_metadata_consistency_check_can_be_disabled():
+    md = DictMetaData(['a', 'b'], original_keys=['a', 'c'], check_keys_consistency=False)
+    assert list(md) == ['a', 'b']
+    assert list(md.original_keys) == ['a', 'c']
+
+
+def test_dict_metadata_is_a_list_for_backward_compat():
+    md = DictMetaData(['a', 'b'], original_keys=['b', 'a'])
+    assert isinstance(md, list)
+    assert md == ['a', 'b']
+    assert md[0] == 'a'
+    assert md[-1] == 'b'
+    assert len(md) == 2
+    assert ['a', 'b'] == md
+
+
+def test_dict_metadata_pickle_roundtrip():
+    md = DictMetaData(['a', 'b', 'c'], original_keys=['c', 'a', 'b'])
+    restored = pickle.loads(pickle.dumps(md))
+    assert isinstance(restored, DictMetaData)
+    assert list(restored) == ['a', 'b', 'c']
+    assert list(restored.original_keys) == ['c', 'a', 'b']
+    assert restored == md
+
+
+def test_dict_metadata_copy_roundtrip():
+    md = DictMetaData(['a', 'b', 'c'], original_keys=['c', 'a', 'b'])
+    shallow = copy.copy(md)
+    assert isinstance(shallow, DictMetaData)
+    assert list(shallow) == ['a', 'b', 'c']
+    assert list(shallow.original_keys) == ['c', 'a', 'b']
+    assert shallow == md
+
+
+def test_dict_metadata_deepcopy_roundtrip():
+    md = DictMetaData(['a', 'b', 'c'], original_keys=['c', 'a', 'b'])
+    deep = copy.deepcopy(md)
+    assert isinstance(deep, DictMetaData)
+    assert list(deep) == ['a', 'b', 'c']
+    assert list(deep.original_keys) == ['c', 'a', 'b']
+    assert deep == md
+    deep.append('z')
+    assert list(md) == ['a', 'b', 'c']
+
+
+@parametrize(
+    namespace=['', 'namespace'],
+    dict_should_be_sorted=[False, True],
+    dict_session_namespace=['', 'namespace'],
+)
+def test_python_dict_flatten_returns_dict_metadata(
+    namespace,
+    dict_should_be_sorted,
+    dict_session_namespace,
+):
+    use_sorted_keys = dict_should_be_sorted or dict_session_namespace not in {'', namespace}
+    dct = {'b': 2, 'a': 1, 'c': 3}
+    with optree.dict_insertion_ordered(
+        not dict_should_be_sorted,
+        namespace=dict_session_namespace or GLOBAL_NAMESPACE,
+    ):
+        children, metadata, entries, _ = optree.tree_flatten_one_level(dct, namespace=namespace)
+        assert children == ([1, 2, 3] if use_sorted_keys else [2, 1, 3])
+        assert isinstance(metadata, DictMetaData)
+        assert list(metadata) == (['a', 'b', 'c'] if use_sorted_keys else ['b', 'a', 'c'])
+        assert list(metadata.original_keys) == ['b', 'a', 'c']
+        assert entries == tuple(metadata)
+
+
+@parametrize(
+    namespace=['', 'namespace'],
+    dict_should_be_sorted=[False, True],
+    dict_session_namespace=['', 'namespace'],
+)
+def test_python_dict_unflatten_preserves_original_insertion_order(
+    namespace,
+    dict_should_be_sorted,
+    dict_session_namespace,
+):
+    dct = {'b': 2, 'a': 1, 'c': 3}
+    with optree.dict_insertion_ordered(
+        not dict_should_be_sorted,
+        namespace=dict_session_namespace or GLOBAL_NAMESPACE,
+    ):
+        (
+            children,
+            metadata,
+            _,
+            unflatten_func,
+        ) = optree.tree_flatten_one_level(dct, namespace=namespace)
+        restored = unflatten_func(metadata, children)
+        assert restored == dct
+        # `tree_unflatten` always reconstructs dicts in their original insertion order, regardless
+        # of whether the flatten path sorted the children.
+        assert list(restored) == ['b', 'a', 'c']
+
+
+def test_python_dict_unflatten_accepts_plain_list_metadata():
+    # `treespec.walk` exposes the C++ `node.node_data` (a plain sorted-keys list) to user-facing
+    # callbacks without `original_keys`. The registered Python `unflatten` function must accept that
+    # path and fall back to plain dict construction.
+    values, metadata, _, unflatten_func = optree.tree_flatten_one_level({'b': 2, 'a': 1, 'c': 3})
+    assert values == [1, 2, 3]
+    assert isinstance(metadata, DictMetaData)
+    assert list(metadata) == ['a', 'b', 'c']
+    assert list(metadata.original_keys) == ['b', 'a', 'c']
+    restored = unflatten_func(['b', 'a', 'c'], (2, 1, 3))
+    assert restored == {'b': 2, 'a': 1, 'c': 3}
+    assert list(restored) == ['b', 'a', 'c']
+    restored = unflatten_func(['a', 'b', 'c'], (1, 2, 3))
+    assert restored == {'a': 1, 'b': 2, 'c': 3}
+    assert list(restored) == ['a', 'b', 'c']
+
+
+def test_python_dict_flatten_equal_inputs_produce_equal_metadata():
+    _, metadata1, _, _ = optree.tree_flatten_one_level({'b': 2, 'a': 1, 'c': 3})
+    _, metadata2, _, _ = optree.tree_flatten_one_level({'a': 1, 'b': 2, 'c': 3})
+    assert metadata1 == metadata2
+    assert list(metadata1) == list(metadata2)
+    assert metadata1.original_keys == metadata2.original_keys
+    assert list(metadata1.original_keys) != list(metadata2.original_keys)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1457,9 +1457,10 @@ def test_python_dict_unflatten_preserves_original_insertion_order(
 
 
 def test_python_dict_unflatten_accepts_plain_list_metadata():
-    # `treespec.walk` exposes the C++ `node.node_data` (a plain sorted-keys list) to user-facing
-    # callbacks without `original_keys`. The registered Python `unflatten` function must accept that
-    # path and fall back to plain dict construction.
+    # `treespec.walk` exposes the C++ `node.node_data` (a plain list of keys, possibly sorted
+    # depending on the active mode) to user-facing callbacks without `original_keys`. The
+    # registered Python `unflatten` function must accept that path and fall back to plain dict
+    # construction, regardless of whether the supplied list is in sorted or insertion order.
     values, metadata, _, unflatten_func = optree.tree_flatten_one_level({'b': 2, 'a': 1, 'c': 3})
     assert values == [1, 2, 3]
     assert isinstance(metadata, DictMetaData)

--- a/tests/test_treespec.py
+++ b/tests/test_treespec.py
@@ -1437,6 +1437,7 @@ def test_treespec_constructor(  # noqa: C901
     dict_should_be_sorted,
     dict_session_namespace,
 ):
+    use_sorted_keys = dict_should_be_sorted or dict_session_namespace not in {'', namespace}
     with optree.dict_insertion_ordered(
         not dict_should_be_sorted,
         namespace=dict_session_namespace or GLOBAL_NAMESPACE,
@@ -1554,7 +1555,7 @@ def test_treespec_constructor(  # noqa: C901
                                 == expected_treespec
                             )
                     elif node_type is dict:
-                        if dict_should_be_sorted or dict_session_namespace not in {'', namespace}:
+                        if use_sorted_keys:
                             assert (
                                 optree.treespec_dict(
                                     zip(sorted(node), children_treespecs),
@@ -1615,7 +1616,7 @@ def test_treespec_constructor(  # noqa: C901
                             == expected_treespec
                         )
                     elif node_type is defaultdict:
-                        if dict_should_be_sorted or dict_session_namespace not in {'', namespace}:
+                        if use_sorted_keys:
                             assert (
                                 optree.treespec_defaultdict(
                                     node.default_factory,


### PR DESCRIPTION
## Description

Describe your changes in detail.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
You can use the syntax `close #15213` if this solves the issue #15213

- [ ] I have raised an issue to propose this change ([required](https://github.com/metaopt/optree/issues) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds core functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [X] I have read the [CONTRIBUTION](https://github.com/metaopt/optree/blob/HEAD/CONTRIBUTING.md) guide. (**required**)
- [X] My change requires a change to the documentation.
- [X] I have updated the tests accordingly. (*required for a bug fix or a new feature*)
- [X] I have updated the documentation accordingly.
- [X] I have reformatted the code using `make format`. (**required**)
- [X] I have checked the code using `make lint`. (**required**)
- [X] I have ensured `make test` pass. (**required**)
